### PR TITLE
Add bytea column support for binary data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Features
 | Scalar (non-singleton) | value | Yes |
 | Hash (singleton) | value | Yes |
 | Hash (singleton) | key/field | No |
-| Hash (non-singleton) | value array | No |
+| Hash (non-singleton) | value array | Yes (`bytea[]`) |
 | Set (singleton) | member | Yes |
 | Set (non-singleton) | value array | Yes (`bytea[]`) |
 | Zset (singleton) | member | Yes |
@@ -420,7 +420,8 @@ Limitations
 
 ### Binary data (bytea)
 - `bytea` is not supported for hash field/key columns (only hash value columns).
-- Non-singleton hash tables do not support `bytea[]` array columns.
+- A non-singleton collection table (hash, list, set, zset) must declare its
+  value column as an array type; a scalar `bytea` value column is rejected.
 
 ### Other
 - Redis has acquired cursors in 2.8+. This is used in all the

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ Features
   priority column
   - non-singleton non-scalar tables must have an array type for the second column
 
+### Binary data (bytea) support
+
+`redis_fdw` supports `bytea` columns for storing binary data, including data with embedded NUL bytes. Binary data is handled using Redis's binary-safe commands. The following table types and columns support `bytea`:
+
+| Table Type | Column | bytea Supported |
+|------------|--------|-----------------|
+| Scalar (singleton) | value | Yes |
+| Scalar (non-singleton) | value | Yes |
+| Hash (singleton) | value | Yes |
+| Hash (singleton) | key/field | No |
+| Hash (non-singleton) | value array | No |
+| Set (singleton) | member | Yes |
+| Set (non-singleton) | value array | Yes (`bytea[]`) |
+| Zset (singleton) | member | Yes |
+| Zset (singleton) | score | No (must be numeric) |
+| Zset (non-singleton) | value array | Yes (`bytea[]`) |
+| List (singleton) | value | Yes |
+
 ### Pushdowning
 
 Not supported, there is no common calculations in Redis.
@@ -336,6 +354,62 @@ All `CREATE FOREIGN TABLE` SQL commands can be executed as a normal PostgreSQL u
      WHERE key = 'prop2';
 ```
 
+#### Binary data (bytea) examples
+
+Store binary data with embedded NUL bytes in a scalar table:
+```sql
+	CREATE FOREIGN TABLE binary_data (
+	  key text,
+	  val bytea
+	)
+	SERVER redis_server
+	OPTIONS (
+	  database '0',
+	  tablekeyprefix 'bin_'
+	);
+
+    -- Insert binary data with embedded NUL byte
+    INSERT INTO binary_data (key, val)
+    VALUES ('bin_image', E'\\x89504e470d0a1a0a'::bytea);
+
+    SELECT key, length(val), val FROM binary_data;
+```
+
+Store binary members in a singleton set:
+```sql
+	CREATE FOREIGN TABLE binary_set (
+	  member bytea
+	)
+	SERVER redis_server
+	OPTIONS (
+	  database '0',
+	  tabletype 'set',
+	  singleton_key 'binary_members'
+	);
+
+    INSERT INTO binary_set VALUES
+        (E'data\\000with\\000nulls'::bytea);
+
+    SELECT length(member), member FROM binary_set;
+```
+
+Store binary data in a hash value column:
+```sql
+	CREATE FOREIGN TABLE binary_hash (
+	  field text,
+	  data bytea
+	)
+	SERVER redis_server
+	OPTIONS (
+	  database '0',
+	  tabletype 'hash',
+	  singleton_key 'binary_hash_key'
+	);
+
+    INSERT INTO binary_hash VALUES
+        ('file1', E'\\x00\\x01\\x02\\x03'::bytea);
+```
+
 Limitations
 -----------
 
@@ -343,6 +417,10 @@ Limitations
 - `COPY` command for foreign tables is not supported.
 - `TRUNCATE` is not supported.
 - `RETURNING` is not supported.
+
+### Binary data (bytea)
+- `bytea` is not supported for hash field/key columns (only hash value columns).
+- Non-singleton hash tables do not support `bytea[]` array columns.
 
 ### Other
 - Redis has acquired cursors in 2.8+. This is used in all the

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -32,6 +32,7 @@
 
 
 #include "funcapi.h"
+#include "access/htup_details.h"
 #include "access/reloptions.h"
 #include "access/sysattr.h"
 #include "access/table.h"
@@ -128,13 +129,14 @@ typedef enum
 
 /*
  * Column type categories for efficient data extraction.
- * REDIS_VAL_TEXT can use VARDATA_ANY directly.
+ * REDIS_VAL_TEXT and REDIS_VAL_BYTEA can use VARDATA_ANY directly.
  * REDIS_VAL_OTHER requires OutputFunctionCall conversion.
  */
 typedef enum
 {
 	REDIS_VAL_OTHER = 0,		/* use OutputFunctionCall */
-	REDIS_VAL_TEXT				/* text/varchar - use VARDATA_ANY */
+	REDIS_VAL_TEXT,				/* text/varchar - use VARDATA_ANY */
+	REDIS_VAL_BYTEA				/* bytea - use VARDATA_ANY */
 } redis_val_type;
 
 typedef struct redisTableOptions
@@ -191,6 +193,10 @@ typedef struct RedisFdwExecutionState
 	char	   *cursor_search_string;
 	char	   *cursor_id;
 	MemoryContext mctxt;
+	redis_val_type *val_types;	/* column value type categories */
+	int			natts;			/* number of attributes */
+	TupleDesc	tupdesc;		/* cached tuple descriptor */
+	Oid			array_elem_type;	/* element type if value column is array */
 } RedisFdwExecutionState;
 
 typedef struct RedisFdwModifyState
@@ -350,6 +356,7 @@ static char *redis_escape_glob(const char *str);
 #define RTYPE_ANY	0
 
 static char *redis_array_to_text(redisReply *reply);
+static Datum process_redis_array(redisReply *reply, Oid elem_type);
 static void check_reply(redisReply *reply, redisContext *context,
 						int allowed, int error_code, char *message, char *arg);
 static redisReply *redis_command_impl(redisContext *context,
@@ -1693,6 +1700,24 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 	festate->attinmeta =
 		TupleDescGetAttInMetadata(node->ss.ss_currentRelation->rd_att);
 
+	/* Cache tuple descriptor and build val_types array for type handling */
+	festate->tupdesc = node->ss.ss_currentRelation->rd_att;
+	festate->natts = festate->tupdesc->natts;
+	festate->val_types = (redis_val_type *) palloc0(sizeof(redis_val_type) * festate->natts);
+	for (int i = 0; i < festate->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, i);
+		festate->val_types[i] = classify_type(attr->atttypid);
+	}
+
+	/* Get array element type for value column (column 2) if it's an array */
+	festate->array_elem_type = InvalidOid;
+	if (festate->natts >= 2)
+	{
+		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, 1);
+		festate->array_elem_type = get_element_type(attr->atttypid);
+	}
+
 	if (festate->singleton_key)
 	{
 		festate->owned_reply = reply;
@@ -1779,8 +1804,12 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 	redisReply *reply = 0;
 	char	   *key;
 	char	   *data = 0;
+	size_t		data_len = 0;
 	char	  **values;
 	HeapTuple	tuple;
+	bool		has_bytea = false;
+	bool		has_array = false;
+	Datum		array_datum = (Datum) 0;
 
 	RedisFdwExecutionState *festate = (RedisFdwExecutionState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
@@ -1791,6 +1820,19 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 
 	/* Cleanup */
 	ExecClearTuple(slot);
+
+	/*
+	 * Check if the value column (column 2) is bytea or an array type.
+	 * For scalar tables: bytea value column (has_bytea = true)
+	 * For set/zset/hash/list tables: array column (has_array = true)
+	 */
+	if (festate->natts >= 2)
+	{
+		if (festate->val_types[1] == REDIS_VAL_BYTEA)
+			has_bytea = true;
+		else if (festate->array_elem_type != InvalidOid)
+			has_array = true;
+	}
 
 	/* Get the next record, and set found */
 	found = false;
@@ -1957,17 +1999,21 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 			{
 				case REDIS_REPLY_INTEGER:
 					data = (char *) palloc(sizeof(char) * 64);
-					snprintf(data, 64, "%lld", reply->integer);
+					data_len = snprintf(data, 64, "%lld", reply->integer);
 					found = true;
 					break;
 
 				case REDIS_REPLY_STRING:
 					data = reply->str;
+					data_len = reply->len;
 					found = true;
 					break;
 
 				case REDIS_REPLY_ARRAY:
-					data = redis_array_to_text(reply);
+					if (has_array)
+						array_datum = process_redis_array(reply, festate->array_elem_type);
+					else
+						data = redis_array_to_text(reply);
 					found = true;
 					break;
 			}
@@ -1981,11 +2027,50 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 	/* Build the tuple */
 	if (found)
 	{
-		values = (char **) palloc(sizeof(char *) * 2);
-		values[0] = key;
-		values[1] = data;
-		tuple = BuildTupleFromCStrings(festate->attinmeta, values);
-		ExecStoreHeapTuple(tuple, slot, false);
+		if (has_bytea || has_array)
+		{
+			/* Use heap_form_tuple for bytea or array columns */
+			Datum	   *datums;
+			bool	   *nulls;
+
+			datums = (Datum *) palloc(sizeof(Datum) * festate->natts);
+			nulls = (bool *) palloc0(sizeof(bool) * festate->natts);
+
+			/* Column 0: key (always text) */
+			datums[0] = CStringGetTextDatum(key);
+
+			/* Column 1: value */
+			if (has_array)
+			{
+				if (array_datum == (Datum) 0)
+					nulls[1] = true;
+				else
+					datums[1] = array_datum;
+			}
+			else if (data == NULL)
+			{
+				nulls[1] = true;
+			}
+			else
+			{
+				bytea	   *bval = (bytea *) palloc(data_len + VARHDRSZ);
+				SET_VARSIZE(bval, data_len + VARHDRSZ);
+				memcpy(VARDATA(bval), data, data_len);
+				datums[1] = PointerGetDatum(bval);
+			}
+
+			tuple = heap_form_tuple(festate->tupdesc, datums, nulls);
+			ExecStoreHeapTuple(tuple, slot, false);
+		}
+		else
+		{
+			/* Use BuildTupleFromCStrings for text-only scalar tables */
+			values = (char **) palloc(sizeof(char *) * 2);
+			values[0] = key;
+			values[1] = data;
+			tuple = BuildTupleFromCStrings(festate->attinmeta, values);
+			ExecStoreHeapTuple(tuple, slot, false);
+		}
 	}
 
 	/* Cleanup */
@@ -2001,8 +2086,11 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 	bool		found;
 	char	   *key = NULL;
 	char	   *data = NULL;
+	size_t		key_len = 0;
+	size_t		data_len = 0;
 	char	  **values;
 	HeapTuple	tuple;
+	bool		has_bytea = false;
 
 	RedisFdwExecutionState *festate = (RedisFdwExecutionState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
@@ -2017,6 +2105,16 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 	if (festate->row < 0)
 		return slot;
 
+	/* Check if any column is bytea */
+	for (int i = 0; i < festate->natts; i++)
+	{
+		if (festate->val_types[i] == REDIS_VAL_BYTEA)
+		{
+			has_bytea = true;
+			break;
+		}
+	}
+
 	/* Get the next record, and set found */
 	found = false;
 
@@ -2027,12 +2125,13 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 		{
 			case REDIS_REPLY_INTEGER:
 				key = (char *) palloc(sizeof(char) * 64);
-				snprintf(key, 64, "%lld", festate->reply->integer);
+				key_len = snprintf(key, 64, "%lld", festate->reply->integer);
 				found = true;
 				break;
 
 			case REDIS_REPLY_STRING:
 				key = festate->reply->str;
+				key_len = festate->reply->len;
 				found = true;
 				break;
 
@@ -2047,16 +2146,18 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 	{
 		festate->row = -1;		/* just one row for qual'd search in a hash */
 		key = festate->qual_value;
+		key_len = strlen(key);
 		switch (festate->reply->type)
 		{
 			case REDIS_REPLY_INTEGER:
 				data = (char *) palloc(sizeof(char) * 64);
-				snprintf(data, 64, "%lld", festate->reply->integer);
+				data_len = snprintf(data, 64, "%lld", festate->reply->integer);
 				found = true;
 				break;
 
 			case REDIS_REPLY_STRING:
 				data = festate->reply->str;
+				data_len = festate->reply->len;
 				found = true;
 				break;
 
@@ -2072,6 +2173,7 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 		/* everything else comes in as an array reply type */
 		found = true;
 		key = festate->reply->element[festate->row]->str;
+		key_len = festate->reply->element[festate->row]->len;
 		festate->row++;
 		if (festate->table_type == PG_REDIS_HASH_TABLE ||
 			festate->table_type == PG_REDIS_ZSET_TABLE)
@@ -2082,11 +2184,12 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 			{
 				case REDIS_REPLY_INTEGER:
 					data = (char *) palloc(sizeof(char) * 64);
-					snprintf(key, 64, "%lld", dreply->integer);
+					data_len = snprintf(data, 64, "%lld", dreply->integer);
 					break;
 
 				case REDIS_REPLY_STRING:
 					data = dreply->str;
+					data_len = dreply->len;
 					break;
 
 				case REDIS_REPLY_ARRAY:
@@ -2101,14 +2204,71 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 	}
 
 	/* Build the tuple */
-	values = (char **) palloc(sizeof(char *) * 2);
-
 	if (found)
 	{
-		values[0] = key;
-		values[1] = data;
-		tuple = BuildTupleFromCStrings(festate->attinmeta, values);
-		ExecStoreHeapTuple(tuple, slot, false);
+		if (has_bytea)
+		{
+			/* Use heap_form_tuple for bytea columns to preserve binary data */
+			Datum	   *datums;
+			bool	   *nulls;
+
+			datums = (Datum *) palloc(sizeof(Datum) * festate->natts);
+			nulls = (bool *) palloc0(sizeof(bool) * festate->natts);
+
+			for (int i = 0; i < festate->natts; i++)
+			{
+				char	   *val;
+				size_t		val_len;
+
+				if (i == 0)
+				{
+					val = key;
+					val_len = key_len;
+				}
+				else
+				{
+					val = data;
+					val_len = data_len;
+				}
+
+				if (val == NULL)
+				{
+					nulls[i] = true;
+				}
+				else if (festate->val_types[i] == REDIS_VAL_BYTEA)
+				{
+					/* Construct bytea datum directly from binary data */
+					bytea	   *bval = (bytea *) palloc(val_len + VARHDRSZ);
+					SET_VARSIZE(bval, val_len + VARHDRSZ);
+					memcpy(VARDATA(bval), val, val_len);
+					datums[i] = PointerGetDatum(bval);
+				}
+				else if (festate->val_types[i] == REDIS_VAL_TEXT)
+				{
+					datums[i] = CStringGetTextDatum(val);
+				}
+				else
+				{
+					/* Use InputFunctionCall for other column types */
+					datums[i] = InputFunctionCall(&festate->attinmeta->attinfuncs[i],
+												  val,
+												  festate->attinmeta->attioparams[i],
+												  festate->attinmeta->atttypmods[i]);
+				}
+			}
+
+			tuple = heap_form_tuple(festate->tupdesc, datums, nulls);
+			ExecStoreHeapTuple(tuple, slot, false);
+		}
+		else
+		{
+			/* Use BuildTupleFromCStrings for text-only tables */
+			values = (char **) palloc(sizeof(char *) * 2);
+			values[0] = key;
+			values[1] = data;
+			tuple = BuildTupleFromCStrings(festate->attinmeta, values);
+			ExecStoreHeapTuple(tuple, slot, false);
+		}
 	}
 
 	return slot;
@@ -2264,6 +2424,95 @@ redis_array_to_text(redisReply *reply)
 	appendStringInfoChar(res, '}');
 
 	return res->data;
+}
+
+/*
+ * process_redis_array
+ *		Build a text[] or bytea[] datum from a Redis array reply.
+ *		For bytea, this preserves binary data including embedded NUL bytes.
+ *		For text, validates UTF-8 encoding.
+ */
+static Datum
+process_redis_array(redisReply *reply, Oid elem_type)
+{
+	Datum	   *elems;
+	int			nelems = reply->elements;
+	ArrayType  *result;
+	bool		is_bytea = (elem_type == BYTEAOID);
+	int16		typlen;
+	bool		typbyval;
+	char		typalign;
+
+	elems = (Datum *) palloc(sizeof(Datum) * nelems);
+
+	for (int i = 0; i < nelems; i++)
+	{
+		redisReply *ir = reply->element[i];
+
+		if (ir->type == REDIS_REPLY_ARRAY)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("nested array returns not yet supported")));
+
+		switch (ir->type)
+		{
+			case REDIS_REPLY_STATUS:
+			case REDIS_REPLY_STRING:
+				if (is_bytea)
+				{
+					bytea	   *bval = (bytea *) palloc(ir->len + VARHDRSZ);
+
+					SET_VARSIZE(bval, ir->len + VARHDRSZ);
+					memcpy(VARDATA(bval), ir->str, ir->len);
+					elems[i] = PointerGetDatum(bval);
+				}
+				else
+				{
+					pg_verifymbstr(ir->str, ir->len, false);
+					elems[i] = PointerGetDatum(cstring_to_text_with_len(ir->str, ir->len));
+				}
+				break;
+			case REDIS_REPLY_INTEGER:
+				{
+					char		buf[64];
+					int			len;
+
+					len = snprintf(buf, sizeof(buf), "%lld", ir->integer);
+					if (is_bytea)
+					{
+						bytea	   *bval = (bytea *) palloc(len + VARHDRSZ);
+
+						SET_VARSIZE(bval, len + VARHDRSZ);
+						memcpy(VARDATA(bval), buf, len);
+						elems[i] = PointerGetDatum(bval);
+					}
+					else
+					{
+						elems[i] = PointerGetDatum(cstring_to_text_with_len(buf, len));
+					}
+				}
+				break;
+			case REDIS_REPLY_NIL:
+			default:
+				/* Create an empty value for NULL/unknown types */
+				if (is_bytea)
+				{
+					bytea	   *bval = (bytea *) palloc(VARHDRSZ);
+
+					SET_VARSIZE(bval, VARHDRSZ);
+					elems[i] = PointerGetDatum(bval);
+				}
+				else
+				{
+					elems[i] = PointerGetDatum(cstring_to_text(""));
+				}
+				break;
+		}
+	}
+
+	get_typlenbyvalalign(elem_type, &typlen, &typbyval, &typalign);
+	result = construct_array(elems, nelems, elem_type, typlen, typbyval, typalign);
+	return PointerGetDatum(result);
 }
 
 static void
@@ -2452,6 +2701,10 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 		fmstate->keyAttno = ExecFindJunkAttributeInTlist(subplan->targetlist,
 														 REDISMODKEYNAME);
 
+		/*
+		 * Classify key column type - needed for DELETE and UPDATE
+		 * operations on singleton SET/ZSET tables with bytea members.
+		 */
 		fmstate->val_types[0] = classify_type(attr->atttypid);
 
 		getTypeOutputInfo(attr->atttypid, &typefnoid, &isvarlena);
@@ -2485,7 +2738,32 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 						 ));
 			}
 
+			/*
+			 * Check for bytea columns and validate they're used appropriately.
+			 * Bytea is supported for:
+			 * - Scalar tables: value column (singleton or non-singleton)
+			 * - Hash singleton tables: value column only (not the field/key column)
+			 * - Set singleton tables: member column
+			 * - Zset singleton tables: member column (not the score column)
+			 * - List singleton tables: value column
+			 */
 			fmstate->val_types[fmstate->p_nums] = classify_type(attr->atttypid);
+			if (fmstate->val_types[fmstate->p_nums] == REDIS_VAL_BYTEA)
+			{
+				/* bytea key column not allowed for non-singleton tables */
+				if (attnum == 1 && !fmstate->singleton_key)
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("bytea key column not supported")));
+
+				/* For hash singleton: field column (attnum 1) must be text */
+				if (fmstate->singleton_key &&
+					fmstate->table_type == PG_REDIS_HASH_TABLE &&
+					attnum == 1)
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("bytea not supported for hash field column")));
+			}
 
 			/*
 			 * If the item is an array, store the output details for its
@@ -2713,6 +2991,8 @@ classify_type(Oid typid)
 		case VARCHAROID:
 		case BPCHAROID:
 			return REDIS_VAL_TEXT;
+		case BYTEAOID:
+			return REDIS_VAL_BYTEA;
 		default:
 			return REDIS_VAL_OTHER;
 	}
@@ -2722,6 +3002,7 @@ classify_type(Oid typid)
  * get_datum_as_string
  *		Extract string data and length from a datum based on its type category.
  *		For text-like types, extracts varlena data directly.
+ *		For bytea, extracts raw binary data.
  *		For other types, uses OutputFunctionCall (caller must ensure result is pfree'd).
  */
 static void
@@ -2736,6 +3017,14 @@ get_datum_as_string(Datum datum, redis_val_type valtype,
 
 				*data = VARDATA_ANY(t);
 				*len = VARSIZE_ANY_EXHDR(t);
+			}
+			break;
+		case REDIS_VAL_BYTEA:
+			{
+				bytea	   *b = DatumGetByteaPP(datum);
+
+				*data = VARDATA_ANY(b);
+				*len = VARSIZE_ANY_EXHDR(b);
 			}
 			break;
 		case REDIS_VAL_OTHER:
@@ -3286,6 +3575,11 @@ redisExecForeignUpdate(EState *estate,
 	ListCell   *lc = NULL;
 	int			flslot = 1;
 	int			nitems = 0;
+	/* For bytea support */
+	bool		value_is_bytea = false;
+	Datum		bytea_datum = 0;
+	/* For old key bytea (SET/ZSET member being replaced) */
+	bool		old_key_is_bytea = false;
 	/* For array updates */
 	Datum	   *array_elems = NULL;
 	redis_val_type array_elem_valtype = REDIS_VAL_OTHER;
@@ -3303,6 +3597,17 @@ redisExecForeignUpdate(EState *estate,
 	get_datum_as_string(datum, fmstate->val_types[0],
 						&fmstate->p_flinfo[0], &key_data, &key_len);
 	keyval = OutputFunctionCall(&fmstate->p_flinfo[0], datum);
+
+	/*
+	 * For singleton set/zset tables with bytea members, mark old key as bytea.
+	 */
+	if (fmstate->singleton_key &&
+		(fmstate->table_type == PG_REDIS_SET_TABLE ||
+		 fmstate->table_type == PG_REDIS_ZSET_TABLE) &&
+		fmstate->val_types[0] == REDIS_VAL_BYTEA)
+	{
+		old_key_is_bytea = true;
+	}
 
 	newkey = keyval;
 	newkey_data = key_data;
@@ -3322,9 +3627,31 @@ redisExecForeignUpdate(EState *estate,
 
 		if (attnum == 1)
 		{
-			newkey = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
-			newkey_len = strlen(newkey);
-			newkey_data = newkey;
+			/*
+			 * For singleton scalar tables, column 1 is the value (stored under
+			 * singleton_key). For singleton set/zset tables, column 1 is the
+			 * member. For bytea, we need to force the "key changed" branch by
+			 * setting newkey to something different from keyval.
+			 */
+			if (fmstate->singleton_key &&
+				(fmstate->table_type == PG_REDIS_SCALAR_TABLE ||
+				 fmstate->table_type == PG_REDIS_SET_TABLE ||
+				 fmstate->table_type == PG_REDIS_ZSET_TABLE) &&
+				fmstate->val_types[flslot] == REDIS_VAL_BYTEA)
+			{
+				value_is_bytea = true;
+				bytea_datum = datum;
+				/* Force entry into key-change branch */
+				newkey = "";
+				get_datum_as_string(datum, REDIS_VAL_BYTEA,
+									NULL, &newkey_data, &newkey_len);
+			}
+			else
+			{
+				newkey = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
+				newkey_len = strlen(newkey);
+				newkey_data = newkey;
+			}
 		}
 		else if (fmstate->singleton_key ||
 				 fmstate->table_type == PG_REDIS_SCALAR_TABLE)
@@ -3333,8 +3660,16 @@ redisExecForeignUpdate(EState *estate,
 			 * non-singleton scalar value, or singleton hash value, or
 			 * singleton zset priority.
 			 */
-			newval = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
-			newval_len = strlen(newval);
+			if (fmstate->val_types[flslot] == REDIS_VAL_BYTEA)
+			{
+				value_is_bytea = true;
+				bytea_datum = datum;
+			}
+			else
+			{
+				newval = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
+				newval_len = strlen(newval);
+			}
 		}
 		else
 		{
@@ -3465,11 +3800,22 @@ redisExecForeignUpdate(EState *estate,
 						"failure renaming key %s", keyval);
 			freeReplyObject(ereply);
 
-			if (newval && fmstate->table_type == PG_REDIS_SCALAR_TABLE)
+			if ((newval || value_is_bytea) && fmstate->table_type == PG_REDIS_SCALAR_TABLE)
 			{
+				const char *data;
+				size_t		len;
+
+				if (value_is_bytea)
+					get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+										NULL, &data, &len);
+				else
+				{
+					data = newval;
+					len = newval_len;
+				}
 				ereply = redis_command(context, "SET",
 									   newkey_data, newkey_len,
-									   NULL, 0, newval, newval_len);
+									   NULL, 0, data, len);
 				check_reply(ereply, context, RTYPE(REDIS_REPLY_STATUS),
 							ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 							"updating key %s", newkey);
@@ -3510,43 +3856,74 @@ redisExecForeignUpdate(EState *estate,
 			switch (fmstate->table_type)
 			{
 				case PG_REDIS_SCALAR_TABLE:
-					ereply = redis_command(context, "SET",
-										   fmstate->singleton_key, fmstate->singleton_key_len,
-										   NULL, 0, newkey_data, newkey_len);
-					check_reply(ereply, context, RTYPE(REDIS_REPLY_STATUS),
-								ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
-								"setting value %s", newkey);
-					freeReplyObject(ereply);
+					{
+						const char *data;
+						size_t		len;
+
+						if (value_is_bytea)
+							get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+												NULL, &data, &len);
+						else
+						{
+							data = newkey_data;
+							len = newkey_len;
+						}
+						ereply = redis_command(context, "SET",
+											   fmstate->singleton_key, fmstate->singleton_key_len,
+											   NULL, 0, data, len);
+						check_reply(ereply, context, RTYPE(REDIS_REPLY_STATUS),
+									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+									"setting value %s", newkey);
+						freeReplyObject(ereply);
+					}
 					break;
 				case PG_REDIS_SET_TABLE:
-					/* add before removing - see the keyset case above */
-					ereply = redis_command(context, "SADD",
-										   fmstate->singleton_key, fmstate->singleton_key_len,
-										   NULL, 0, newkey_data, newkey_len);
-					check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
-								ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
-								"setting value %s", newkey);
-					freeReplyObject(ereply);
-					ereply = redis_command(context, "SREM",
-										   fmstate->singleton_key, fmstate->singleton_key_len,
-										   NULL, 0, key_data, key_len);
-					check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
-								ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
-								"removing value %s", keyval);
-					freeReplyObject(ereply);
+					{
+						const char *new_data;
+						size_t		new_len;
+
+						if (value_is_bytea)
+							get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+												NULL, &new_data, &new_len);
+						else
+						{
+							new_data = newkey_data;
+							new_len = newkey_len;
+						}
+
+						/* add before removing - see the keyset case above */
+						ereply = redis_command(context, "SADD",
+											   fmstate->singleton_key, fmstate->singleton_key_len,
+											   NULL, 0, new_data, new_len);
+						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+									"setting value %s", newkey);
+						freeReplyObject(ereply);
+
+						ereply = redis_command(context, "SREM",
+											   fmstate->singleton_key, fmstate->singleton_key_len,
+											   NULL, 0, key_data, key_len);
+						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+									"removing value %s", keyval);
+						freeReplyObject(ereply);
+					}
 					break;
 				case PG_REDIS_ZSET_TABLE:
 					{
 						char	   *priority = newval;
 						size_t		priority_len;
+						const char *new_data;
+						size_t		new_len;
 
 						if (!priority)
 						{
+							/* Get current score */
 							ereply = redis_command(context, "ZSCORE",
 												   fmstate->singleton_key, fmstate->singleton_key_len,
 												   NULL, 0, key_data, key_len);
 							check_reply(ereply, context, RTYPE(REDIS_REPLY_STRING),
-									  ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+										ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 										"getting score for key %s", keyval);
 							/*
 							 * Copy by length, not pstrdup: a Redis value is
@@ -3562,6 +3939,16 @@ redisExecForeignUpdate(EState *estate,
 						else
 							priority_len = newval_len;
 
+						/* Add new member */
+						if (value_is_bytea)
+							get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+												NULL, &new_data, &new_len);
+						else
+						{
+							new_data = newkey_data;
+							new_len = newkey_len;
+						}
+
 						/*
 						 * Add before removing - see the keyset case above.
 						 * The score was read from the old member further up,
@@ -3570,7 +3957,7 @@ redisExecForeignUpdate(EState *estate,
 						 */
 						ereply = redis_command(context, "ZADD",
 											   fmstate->singleton_key, fmstate->singleton_key_len,
-											   priority, priority_len, newkey_data, newkey_len);
+											   priority, priority_len, new_data, new_len);
 						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
 									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 									"setting element %s", newkey);
@@ -3589,14 +3976,16 @@ redisExecForeignUpdate(EState *estate,
 					{
 						char	   *nval = newval;
 						size_t		nval_len;
+						const char *val_data;
+						size_t		val_len;
 
-						if (!nval)
+						if (!nval && !value_is_bytea)
 						{
 							ereply = redis_command(context, "HGET",
 												   fmstate->singleton_key, fmstate->singleton_key_len,
 												   NULL, 0, key_data, key_len);
 							check_reply(ereply, context, RTYPE(REDIS_REPLY_STRING),
-									  ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+										ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 										"fetching value for key %s", keyval);
 							/*
 							 * Copy by length, not pstrdup: a Redis hash value
@@ -3620,9 +4009,18 @@ redisExecForeignUpdate(EState *estate,
 									"removing hash element %s", keyval);
 						freeReplyObject(ereply);
 
+						/* Add new entry */
+						if (value_is_bytea)
+							get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+												NULL, &val_data, &val_len);
+						else
+						{
+							val_data = nval;
+							val_len = nval_len;
+						}
 						ereply = redis_command(context, "HSET",
 											   fmstate->singleton_key, fmstate->singleton_key_len,
-											   newkey_data, newkey_len, nval, nval_len);
+											   newkey_data, newkey_len, val_data, val_len);
 						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
 									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 									"adding hash element %s", newkey);
@@ -3634,25 +4032,64 @@ redisExecForeignUpdate(EState *estate,
 			}
 		}
 	}	/* no key update */
-	else if (newval)
+	else if (newval || value_is_bytea)
 	{
 		if (!fmstate->singleton_key)
 		{
+			const char *val_data;
+			size_t		val_len;
+
 			Assert(fmstate->table_type == PG_REDIS_SCALAR_TABLE);
+			if (value_is_bytea)
+				get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+									NULL, &val_data, &val_len);
+			else
+			{
+				val_data = newval;
+				val_len = newval_len;
+			}
 			ereply = redis_command(context, "SET",
 								   key_data, key_len,
-								   NULL, 0, newval, newval_len);
+								   NULL, 0, val_data, val_len);
 		}
 		else
 		{
 			if (fmstate->table_type == PG_REDIS_ZSET_TABLE)
+			{
+				const char *member_data;
+				size_t		member_len;
+
+				if (old_key_is_bytea)
+				{
+					member_data = key_data;
+					member_len = key_len;
+				}
+				else
+				{
+					member_data = key_data;
+					member_len = key_len;
+				}
 				ereply = redis_command(context, "ZADD",
 									   fmstate->singleton_key, fmstate->singleton_key_len,
-									   newval, newval_len, key_data, key_len);
+									   newval, newval_len, member_data, member_len);
+			}
 			else if (fmstate->table_type == PG_REDIS_HASH_TABLE)
+			{
+				const char *val_data;
+				size_t		val_len;
+
+				if (value_is_bytea)
+					get_datum_as_string(bytea_datum, REDIS_VAL_BYTEA,
+										NULL, &val_data, &val_len);
+				else
+				{
+					val_data = newval;
+					val_len = newval_len;
+				}
 				ereply = redis_command(context, "HSET",
 									   fmstate->singleton_key, fmstate->singleton_key_len,
-									   key_data, key_len, newval, newval_len);
+									   key_data, key_len, val_data, val_len);
+			}
 			else
 				elog(ERROR, "impossible update");		/* should not happen */
 		}

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -1563,6 +1563,48 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 		return;
 
+	/* Store the additional state info */
+	festate->attinmeta =
+		TupleDescGetAttInMetadata(node->ss.ss_currentRelation->rd_att);
+
+	/* Cache tuple descriptor and build val_types array for type handling */
+	festate->tupdesc = node->ss.ss_currentRelation->rd_att;
+	festate->natts = festate->tupdesc->natts;
+	festate->val_types = (redis_val_type *) palloc0(sizeof(redis_val_type) * festate->natts);
+	for (int i = 0; i < festate->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, i);
+		festate->val_types[i] = classify_type(attr->atttypid);
+	}
+
+	/* Get array element type for value column (column 2) if it's an array */
+	festate->array_elem_type = InvalidOid;
+	if (festate->natts >= 2)
+	{
+		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, 1);
+		festate->array_elem_type = get_element_type(attr->atttypid);
+	}
+
+	/*
+	 * A collection table keeps its members in an array-typed value column. A
+	 * scalar bytea column cannot represent them: scalar text works only
+	 * because what it yields is a PostgreSQL array literal, and bytea has no
+	 * array literal form. Reject the declaration rather than returning an
+	 * empty bytea; the modify path already refuses this shape. The last
+	 * conjunct is redundant once val_types[1] is REDIS_VAL_BYTEA -- bytea
+	 * never has an element type -- but it is kept to mirror the has_bytea /
+	 * has_array pairing in redisIterateForeignScanMulti, belt and braces.
+	 */
+	if (!festate->singleton_key &&
+		festate->table_type != PG_REDIS_SCALAR_TABLE &&
+		festate->natts >= 2 &&
+		festate->val_types[1] == REDIS_VAL_BYTEA &&
+		festate->array_elem_type == InvalidOid)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("bytea value column requires an array type for this Redis table"),
+				 errhint("Declare the value column as bytea[] instead.")));
+
 	/*
 	 * We're going to use the current scan-lived context to
 	 * store the pstrduped cusrsor id.
@@ -1694,28 +1736,6 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 				(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
 				 errmsg("failed somehow: %s", err)
 				 ));
-	}
-
-	/* Store the additional state info */
-	festate->attinmeta =
-		TupleDescGetAttInMetadata(node->ss.ss_currentRelation->rd_att);
-
-	/* Cache tuple descriptor and build val_types array for type handling */
-	festate->tupdesc = node->ss.ss_currentRelation->rd_att;
-	festate->natts = festate->tupdesc->natts;
-	festate->val_types = (redis_val_type *) palloc0(sizeof(redis_val_type) * festate->natts);
-	for (int i = 0; i < festate->natts; i++)
-	{
-		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, i);
-		festate->val_types[i] = classify_type(attr->atttypid);
-	}
-
-	/* Get array element type for value column (column 2) if it's an array */
-	festate->array_elem_type = InvalidOid;
-	if (festate->natts >= 2)
-	{
-		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, 1);
-		festate->array_elem_type = get_element_type(attr->atttypid);
 	}
 
 	if (festate->singleton_key)

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -2707,6 +2707,19 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 		 */
 		fmstate->val_types[0] = classify_type(attr->atttypid);
 
+		/*
+		 * bytea key column not allowed for non-singleton tables. The
+		 * INSERT/UPDATE loop below also checks this for its own target
+		 * columns, but that loop doesn't run for DELETE, and a bytea key
+		 * sent through the escaped-text OutputFunctionCall path (instead
+		 * of the real binary bytes) would make DEL silently no-op while
+		 * PostgreSQL reports success.
+		 */
+		if (fmstate->val_types[0] == REDIS_VAL_BYTEA && !fmstate->singleton_key)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("bytea key column not supported")));
+
 		getTypeOutputInfo(attr->atttypid, &typefnoid, &isvarlena);
 		fmgr_info(typefnoid, &fmstate->p_flinfo[fmstate->p_nums]);
 		fmstate->p_nums++;
@@ -2750,8 +2763,13 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 			fmstate->val_types[fmstate->p_nums] = classify_type(attr->atttypid);
 			if (fmstate->val_types[fmstate->p_nums] == REDIS_VAL_BYTEA)
 			{
-				/* bytea key column not allowed for non-singleton tables */
-				if (attnum == 1 && !fmstate->singleton_key)
+				/*
+				 * bytea key column not allowed for non-singleton tables.
+				 * For CMD_UPDATE this is already checked above (key
+				 * classification runs for both CMD_UPDATE and CMD_DELETE);
+				 * only CMD_INSERT still needs it here.
+				 */
+				if (attnum == 1 && !fmstate->singleton_key && op == CMD_INSERT)
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("bytea key column not supported")));
@@ -3746,17 +3764,17 @@ redisExecForeignUpdate(EState *estate,
 				case PG_REDIS_SET_TABLE:
 					ereply = redis_command2(context, "SISMEMBER",
 											fmstate->singleton_key, strlen(fmstate->singleton_key),
-											newkey, strlen(newkey));
+											newkey_data, newkey_len);
 					break;
 				case PG_REDIS_ZSET_TABLE:
 					ereply = redis_command2(context, "ZRANK",
 											fmstate->singleton_key, strlen(fmstate->singleton_key),
-											newkey, strlen(newkey));
+											newkey_data, newkey_len);
 					break;
 				case PG_REDIS_HASH_TABLE:
 					ereply = redis_command2(context, "HEXISTS",
 											fmstate->singleton_key, strlen(fmstate->singleton_key),
-											newkey, strlen(newkey));
+											newkey_data, newkey_len);
 					break;
 				default:
 					break;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3616,8 +3616,6 @@ redisExecForeignUpdate(EState *estate,
 	/* For bytea support */
 	bool		value_is_bytea = false;
 	Datum		bytea_datum = 0;
-	/* For old key bytea (SET/ZSET member being replaced) */
-	bool		old_key_is_bytea = false;
 	/* For array updates */
 	Datum	   *array_elems = NULL;
 	redis_val_type array_elem_valtype = REDIS_VAL_OTHER;
@@ -3635,17 +3633,6 @@ redisExecForeignUpdate(EState *estate,
 	get_datum_as_string(datum, fmstate->val_types[0],
 						&fmstate->p_flinfo[0], &key_data, &key_len);
 	keyval = OutputFunctionCall(&fmstate->p_flinfo[0], datum);
-
-	/*
-	 * For singleton set/zset tables with bytea members, mark old key as bytea.
-	 */
-	if (fmstate->singleton_key &&
-		(fmstate->table_type == PG_REDIS_SET_TABLE ||
-		 fmstate->table_type == PG_REDIS_ZSET_TABLE) &&
-		fmstate->val_types[0] == REDIS_VAL_BYTEA)
-	{
-		old_key_is_bytea = true;
-	}
 
 	newkey = keyval;
 	newkey_data = key_data;
@@ -4094,22 +4081,9 @@ redisExecForeignUpdate(EState *estate,
 		{
 			if (fmstate->table_type == PG_REDIS_ZSET_TABLE)
 			{
-				const char *member_data;
-				size_t		member_len;
-
-				if (old_key_is_bytea)
-				{
-					member_data = key_data;
-					member_len = key_len;
-				}
-				else
-				{
-					member_data = key_data;
-					member_len = key_len;
-				}
 				ereply = redis_command(context, "ZADD",
 									   fmstate->singleton_key, fmstate->singleton_key_len,
-									   newval, newval_len, member_data, member_len);
+									   newval, newval_len, key_data, key_len);
 			}
 			else if (fmstate->table_type == PG_REDIS_HASH_TABLE)
 			{

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1999,6 +1999,39 @@ select length(val), val from db15_bytea_list;
      10 | \x6c697374006974656d33
 (3 rows)
 
+-- regression test: bytea key column on a non-singleton table must be
+-- rejected for DELETE too, not just INSERT/UPDATE. Before the fix, DELETE
+-- skipped this check entirely and sent the escaped-text representation of
+-- the key to Redis's DEL command instead of the real binary key, so the
+-- delete would silently affect 0 keys while PostgreSQL reported success.
+create foreign table db15_bytea_key_ns(key bytea, val text)
+       server localredis
+       options (database '15');
+delete from db15_bytea_key_ns where key = E'anything'::bytea; -- bytea key error
+ERROR:  bytea key column not supported
+drop foreign table db15_bytea_key_ns;
+-- regression test: updating a singleton set member to a bytea value that
+-- already exists in the set must be rejected as a duplicate. Before the
+-- fix, the pre-flight SISMEMBER check used a text sentinel ("") instead of
+-- the real new member bytes, so it always reported "not found" and let the
+-- update through regardless of whether the new value already existed.
+create foreign table db15_bytea_set_dup(member bytea)
+       server localredis
+       options (singleton_key 'bytea_set_dup', tabletype 'set', database '15');
+insert into db15_bytea_set_dup values
+    (E'dup\\000existing'::bytea), (E'other\\000member'::bytea);
+update db15_bytea_set_dup set member = E'dup\\000existing'::bytea
+       where member = E'other\\000member'::bytea; -- must fail: key already exists
+ERROR:  key already exists: 
+select length(member), member from db15_bytea_set_dup order by member;
+ length |           member           
+--------+----------------------------
+     12 | \x647570006578697374696e67
+     12 | \x6f74686572006d656d626572
+(2 rows)
+
+delete from db15_bytea_set_dup;
+drop foreign table db15_bytea_set_dup;
 -- clean up bytea tests
 \! redis-cli < test/sql/redis_clean
 OK

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1999,22 +1999,16 @@ select length(val), val from db15_bytea_list;
      10 | \x6c697374006974656d33
 (3 rows)
 
--- regression test: bytea key column on a non-singleton table must be
--- rejected for DELETE too, not just INSERT/UPDATE. Before the fix, DELETE
--- skipped this check entirely and sent the escaped-text representation of
--- the key to Redis's DEL command instead of the real binary key, so the
--- delete would silently affect 0 keys while PostgreSQL reported success.
+-- a bytea key column on a non-singleton table is rejected for DELETE too,
+-- not just INSERT/UPDATE
 create foreign table db15_bytea_key_ns(key bytea, val text)
        server localredis
        options (database '15');
 delete from db15_bytea_key_ns where key = E'anything'::bytea; -- bytea key error
 ERROR:  bytea key column not supported
 drop foreign table db15_bytea_key_ns;
--- regression test: updating a singleton set member to a bytea value that
--- already exists in the set must be rejected as a duplicate. Before the
--- fix, the pre-flight SISMEMBER check used a text sentinel ("") instead of
--- the real new member bytes, so it always reported "not found" and let the
--- update through regardless of whether the new value already existed.
+-- updating a singleton set member to a bytea value that already exists in
+-- the set is rejected as a duplicate
 create foreign table db15_bytea_set_dup(member bytea)
        server localredis
        options (singleton_key 'bytea_set_dup', tabletype 'set', database '15');

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1716,3 +1716,290 @@ NOTICE:  drop cascades to user mapping for public on server aclbad
 \! redis-cli < test/sql/redis_clean
 OK
 OK
+-- =====================================================
+-- bytea column tests
+-- =====================================================
+-- Test that bytea columns work correctly for storing binary data
+-- including data with embedded NUL bytes
+-- singleton scalar table with bytea value
+create foreign table db15_bytea_scalar(val bytea)
+       server localredis
+       options (singleton_key 'bytea_scalar', database '15');
+select * from db15_bytea_scalar;
+ val 
+-----
+(0 rows)
+
+-- insert binary data with embedded NUL bytes
+insert into db15_bytea_scalar values (E'hello\\000world'::bytea);
+select * from db15_bytea_scalar;
+           val            
+--------------------------
+ \x68656c6c6f00776f726c64
+(1 row)
+
+select length(val), val from db15_bytea_scalar;
+ length |           val            
+--------+--------------------------
+     11 | \x68656c6c6f00776f726c64
+(1 row)
+
+-- update with different binary data
+update db15_bytea_scalar set val = E'binary\\000data\\000here'::bytea;
+select length(val), val from db15_bytea_scalar;
+ length |                val                 
+--------+------------------------------------
+     16 | \x62696e61727900646174610068657265
+(1 row)
+
+delete from db15_bytea_scalar;
+select * from db15_bytea_scalar;
+ val 
+-----
+(0 rows)
+
+-- non-singleton scalar table with bytea value column
+create foreign table db15_bytea_scalar_ns(key text, val bytea)
+       server localredis
+       options (database '15', tablekeyprefix 'bscalar_');
+select * from db15_bytea_scalar_ns;
+ key | val 
+-----+-----
+(0 rows)
+
+insert into db15_bytea_scalar_ns values
+    ('bscalar_a', E'binary\\000a'::bytea),
+    ('bscalar_b', E'binary\\000b'::bytea);
+select key, length(val), val from db15_bytea_scalar_ns order by key;
+    key    | length |        val         
+-----------+--------+--------------------
+ bscalar_a |      8 | \x62696e6172790061
+ bscalar_b |      8 | \x62696e6172790062
+(2 rows)
+
+update db15_bytea_scalar_ns set val = E'updated\\000val'::bytea where key = 'bscalar_a';
+select key, length(val), val from db15_bytea_scalar_ns order by key;
+    key    | length |           val            
+-----------+--------+--------------------------
+ bscalar_a |     11 | \x757064617465640076616c
+ bscalar_b |      8 | \x62696e6172790062
+(2 rows)
+
+delete from db15_bytea_scalar_ns where key = 'bscalar_a';
+select key, length(val), val from db15_bytea_scalar_ns order by key;
+    key    | length |        val         
+-----------+--------+--------------------
+ bscalar_b |      8 | \x62696e6172790062
+(1 row)
+
+delete from db15_bytea_scalar_ns;
+select * from db15_bytea_scalar_ns;
+ key | val 
+-----+-----
+(0 rows)
+
+-- singleton hash table with bytea value column (key must be text)
+create foreign table db15_bytea_hash(key text, val bytea)
+       server localredis
+       options (singleton_key 'bytea_hash', tabletype 'hash', database '15');
+select * from db15_bytea_hash;
+ key | val 
+-----+-----
+(0 rows)
+
+insert into db15_bytea_hash values
+    ('field1', E'hash\\000val1'::bytea),
+    ('field2', E'hash\\000val2'::bytea);
+select key, length(val), val from db15_bytea_hash order by key;
+  key   | length |         val          
+--------+--------+----------------------
+ field1 |      9 | \x686173680076616c31
+ field2 |      9 | \x686173680076616c32
+(2 rows)
+
+update db15_bytea_hash set val = E'new\\000hash\\000val'::bytea where key = 'field1';
+select key, length(val), val from db15_bytea_hash order by key;
+  key   | length |            val             
+--------+--------+----------------------------
+ field1 |     12 | \x6e657700686173680076616c
+ field2 |      9 | \x686173680076616c32
+(2 rows)
+
+delete from db15_bytea_hash where key = 'field2';
+select key, length(val), val from db15_bytea_hash order by key;
+  key   | length |            val             
+--------+--------+----------------------------
+ field1 |     12 | \x6e657700686173680076616c
+(1 row)
+
+delete from db15_bytea_hash;
+select * from db15_bytea_hash;
+ key | val 
+-----+-----
+(0 rows)
+
+-- test that bytea key column in hash is rejected
+create foreign table db15_bytea_hash_bad(key bytea, val text)
+       server localredis
+       options (singleton_key 'bytea_hash_bad', tabletype 'hash', database '15');
+insert into db15_bytea_hash_bad values (E'key'::bytea, 'val');
+ERROR:  bytea not supported for hash field column
+-- singleton set table with bytea member
+create foreign table db15_bytea_set(member bytea)
+       server localredis
+       options (singleton_key 'bytea_set', tabletype 'set', database '15');
+select * from db15_bytea_set;
+ member 
+--------
+(0 rows)
+
+insert into db15_bytea_set values
+    (E'set\\000member1'::bytea),
+    (E'set\\000member2'::bytea),
+    (E'set\\000member3'::bytea);
+select length(member), member from db15_bytea_set order by member;
+ length |          member          
+--------+--------------------------
+     11 | \x736574006d656d62657231
+     11 | \x736574006d656d62657232
+     11 | \x736574006d656d62657233
+(3 rows)
+
+delete from db15_bytea_set where member = E'set\\000member2'::bytea;
+select length(member), member from db15_bytea_set order by member;
+ length |          member          
+--------+--------------------------
+     11 | \x736574006d656d62657231
+     11 | \x736574006d656d62657233
+(2 rows)
+
+-- update member
+update db15_bytea_set set member = E'set\\000updated'::bytea where member = E'set\\000member1'::bytea;
+select length(member), member from db15_bytea_set order by member;
+ length |          member          
+--------+--------------------------
+     11 | \x736574006d656d62657233
+     11 | \x7365740075706461746564
+(2 rows)
+
+delete from db15_bytea_set;
+select * from db15_bytea_set;
+ member 
+--------
+(0 rows)
+
+-- singleton zset table with bytea member and scores
+create foreign table db15_bytea_zset(member bytea, score numeric)
+       server localredis
+       options (singleton_key 'bytea_zset', tabletype 'zset', database '15');
+select * from db15_bytea_zset;
+ member | score 
+--------+-------
+(0 rows)
+
+insert into db15_bytea_zset values
+    (E'zset\\000m1'::bytea, 1),
+    (E'zset\\000m2'::bytea, 2),
+    (E'zset\\000m3'::bytea, 3);
+select length(member), member, score from db15_bytea_zset order by score;
+ length |      member      | score 
+--------+------------------+-------
+      7 | \x7a736574006d31 |     1
+      7 | \x7a736574006d32 |     2
+      7 | \x7a736574006d33 |     3
+(3 rows)
+
+delete from db15_bytea_zset where member = E'zset\\000m2'::bytea;
+select length(member), member, score from db15_bytea_zset order by score;
+ length |      member      | score 
+--------+------------------+-------
+      7 | \x7a736574006d31 |     1
+      7 | \x7a736574006d33 |     3
+(2 rows)
+
+update db15_bytea_zset set score = 10 where member = E'zset\\000m1'::bytea;
+select length(member), member, score from db15_bytea_zset order by score;
+ length |      member      | score 
+--------+------------------+-------
+      7 | \x7a736574006d33 |     3
+      7 | \x7a736574006d31 |    10
+(2 rows)
+
+delete from db15_bytea_zset;
+select * from db15_bytea_zset;
+ member | score 
+--------+-------
+(0 rows)
+
+-- non-singleton set table with bytea[] array column
+create foreign table db15_bytea_set_arr(key text, val bytea[])
+       server localredis
+       options (database '15', tabletype 'set', tablekeyprefix 'bset_');
+select * from db15_bytea_set_arr;
+ key | val 
+-----+-----
+(0 rows)
+
+insert into db15_bytea_set_arr values
+    ('bset_a', array[E'a\\000'::bytea, E'b\\000'::bytea, E'c\\000'::bytea]);
+select key, val from db15_bytea_set_arr order by key;
+  key   |               val               
+--------+---------------------------------
+ bset_a | {"\\x6100","\\x6200","\\x6300"}
+(1 row)
+
+delete from db15_bytea_set_arr;
+select * from db15_bytea_set_arr;
+ key | val 
+-----+-----
+(0 rows)
+
+-- non-singleton zset table with bytea[] array column
+create foreign table db15_bytea_zset_arr(key text, val bytea[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bzset_');
+select * from db15_bytea_zset_arr;
+ key | val 
+-----+-----
+(0 rows)
+
+insert into db15_bytea_zset_arr values
+    ('bzset_a', array[E'x\\000'::bytea, E'y\\000'::bytea, E'z\\000'::bytea]);
+select key, val from db15_bytea_zset_arr order by key;
+   key   |               val               
+---------+---------------------------------
+ bzset_a | {"\\x7800","\\x7900","\\x7a00"}
+(1 row)
+
+delete from db15_bytea_zset_arr;
+select * from db15_bytea_zset_arr;
+ key | val 
+-----+-----
+(0 rows)
+
+-- singleton list table with bytea value
+-- note: UPDATE and DELETE not supported for list tables (Redis API limitation)
+create foreign table db15_bytea_list(val bytea)
+       server localredis
+       options (singleton_key 'bytea_list', tabletype 'list', database '15');
+select * from db15_bytea_list;
+ val 
+-----
+(0 rows)
+
+insert into db15_bytea_list values
+    (E'list\\000item1'::bytea),
+    (E'list\\000item2'::bytea),
+    (E'list\\000item3'::bytea);
+select length(val), val from db15_bytea_list;
+ length |          val           
+--------+------------------------
+     10 | \x6c697374006974656d31
+     10 | \x6c697374006974656d32
+     10 | \x6c697374006974656d33
+(3 rows)
+
+-- clean up bytea tests
+\! redis-cli < test/sql/redis_clean
+OK
+OK

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1712,6 +1712,98 @@ NOTICE:  drop cascades to user mapping for public on server aclsrv
 drop server aclbad cascade;
 NOTICE:  drop cascades to user mapping for public on server aclbad
 \! redis-cli ACL DELUSER fdwtest > /dev/null
+-- A collection table stores its members in an array-typed value column. A
+-- scalar bytea column cannot hold them: unlike scalar text, which yields a
+-- PostgreSQL array literal that casts back to an array, bytea has no array
+-- literal form. The write path already refuses this shape; the read path
+-- must too, rather than silently returning an empty bytea.
+\! redis-cli -n 15 rpush bcol_list a b c > /dev/null
+\! redis-cli -n 15 sadd  bcol_set  x y   > /dev/null
+\! redis-cli -n 15 hset  bcol_hash f1 v1 > /dev/null
+\! redis-cli -n 15 zadd  bcol_zset 1 m1  > /dev/null
+create foreign table db15_bcol_list(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'list', tablekeyprefix 'bcol_list');
+select * from db15_bcol_list;
+ERROR:  bytea value column requires an array type for this Redis table
+HINT:  Declare the value column as bytea[] instead.
+-- the check must sit after the EXPLAIN early return: planning must not error
+explain (costs off) select * from db15_bcol_list;
+           QUERY PLAN           
+--------------------------------
+ Foreign Scan on db15_bcol_list
+(1 row)
+
+create foreign table db15_bcol_set(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'set', tablekeyprefix 'bcol_set');
+select * from db15_bcol_set;
+ERROR:  bytea value column requires an array type for this Redis table
+HINT:  Declare the value column as bytea[] instead.
+create foreign table db15_bcol_hash(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'hash', tablekeyprefix 'bcol_hash');
+select * from db15_bcol_hash;
+ERROR:  bytea value column requires an array type for this Redis table
+HINT:  Declare the value column as bytea[] instead.
+create foreign table db15_bcol_zset(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bcol_zset');
+select * from db15_bcol_zset;
+ERROR:  bytea value column requires an array type for this Redis table
+HINT:  Declare the value column as bytea[] instead.
+-- bytea[] on the same table is the correct shape and must keep working
+create foreign table db15_bcol_list_arr(key text, value bytea[])
+       server localredis
+       options (database '15', tabletype 'list', tablekeyprefix 'bcol_list');
+select key, value from db15_bcol_list_arr;
+    key    |           value           
+-----------+---------------------------
+ bcol_list | {"\\x61","\\x62","\\x63"}
+(1 row)
+
+-- a singleton collection with a scalar bytea column is the feature's main
+-- use case and must keep working
+create foreign table db15_bcol_sing_set(member bytea)
+       server localredis
+       options (database '15', tabletype 'set', singleton_key 'bcol_set');
+select member from db15_bcol_sing_set order by member;
+ member 
+--------
+ \x78
+ \x79
+(2 rows)
+
+create foreign table db15_bcol_sing_list(member bytea)
+       server localredis
+       options (database '15', tabletype 'list', singleton_key 'bcol_list');
+select member from db15_bcol_sing_list;
+ member 
+--------
+ \x61
+ \x62
+ \x63
+(3 rows)
+
+-- a scalar table with a bytea value column must keep working
+\! redis-cli -n 15 set bcol_scalar_k hello > /dev/null
+create foreign table db15_bcol_scalar(key text, value bytea)
+       server localredis
+       options (database '15', tablekeyprefix 'bcol_scalar');
+select key, value from db15_bcol_scalar;
+      key      |    value     
+---------------+--------------
+ bcol_scalar_k | \x68656c6c6f
+(1 row)
+
+drop foreign table db15_bcol_list;
+drop foreign table db15_bcol_set;
+drop foreign table db15_bcol_hash;
+drop foreign table db15_bcol_zset;
+drop foreign table db15_bcol_list_arr;
+drop foreign table db15_bcol_sing_set;
+drop foreign table db15_bcol_sing_list;
+drop foreign table db15_bcol_scalar;
 -- all done, so now blow everything in the db away again
 \! redis-cli < test/sql/redis_clean
 OK

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -1173,3 +1173,192 @@ drop server aclbad cascade;
 
 \! redis-cli < test/sql/redis_clean
 
+-- =====================================================
+-- bytea column tests
+-- =====================================================
+
+-- Test that bytea columns work correctly for storing binary data
+-- including data with embedded NUL bytes
+
+-- singleton scalar table with bytea value
+create foreign table db15_bytea_scalar(val bytea)
+       server localredis
+       options (singleton_key 'bytea_scalar', database '15');
+
+select * from db15_bytea_scalar;
+
+-- insert binary data with embedded NUL bytes
+insert into db15_bytea_scalar values (E'hello\\000world'::bytea);
+
+select * from db15_bytea_scalar;
+select length(val), val from db15_bytea_scalar;
+
+-- update with different binary data
+update db15_bytea_scalar set val = E'binary\\000data\\000here'::bytea;
+
+select length(val), val from db15_bytea_scalar;
+
+delete from db15_bytea_scalar;
+
+select * from db15_bytea_scalar;
+
+-- non-singleton scalar table with bytea value column
+create foreign table db15_bytea_scalar_ns(key text, val bytea)
+       server localredis
+       options (database '15', tablekeyprefix 'bscalar_');
+
+select * from db15_bytea_scalar_ns;
+
+insert into db15_bytea_scalar_ns values
+    ('bscalar_a', E'binary\\000a'::bytea),
+    ('bscalar_b', E'binary\\000b'::bytea);
+
+select key, length(val), val from db15_bytea_scalar_ns order by key;
+
+update db15_bytea_scalar_ns set val = E'updated\\000val'::bytea where key = 'bscalar_a';
+
+select key, length(val), val from db15_bytea_scalar_ns order by key;
+
+delete from db15_bytea_scalar_ns where key = 'bscalar_a';
+
+select key, length(val), val from db15_bytea_scalar_ns order by key;
+
+delete from db15_bytea_scalar_ns;
+
+select * from db15_bytea_scalar_ns;
+
+-- singleton hash table with bytea value column (key must be text)
+create foreign table db15_bytea_hash(key text, val bytea)
+       server localredis
+       options (singleton_key 'bytea_hash', tabletype 'hash', database '15');
+
+select * from db15_bytea_hash;
+
+insert into db15_bytea_hash values
+    ('field1', E'hash\\000val1'::bytea),
+    ('field2', E'hash\\000val2'::bytea);
+
+select key, length(val), val from db15_bytea_hash order by key;
+
+update db15_bytea_hash set val = E'new\\000hash\\000val'::bytea where key = 'field1';
+
+select key, length(val), val from db15_bytea_hash order by key;
+
+delete from db15_bytea_hash where key = 'field2';
+
+select key, length(val), val from db15_bytea_hash order by key;
+
+delete from db15_bytea_hash;
+
+select * from db15_bytea_hash;
+
+-- test that bytea key column in hash is rejected
+create foreign table db15_bytea_hash_bad(key bytea, val text)
+       server localredis
+       options (singleton_key 'bytea_hash_bad', tabletype 'hash', database '15');
+
+insert into db15_bytea_hash_bad values (E'key'::bytea, 'val');
+
+-- singleton set table with bytea member
+create foreign table db15_bytea_set(member bytea)
+       server localredis
+       options (singleton_key 'bytea_set', tabletype 'set', database '15');
+
+select * from db15_bytea_set;
+
+insert into db15_bytea_set values
+    (E'set\\000member1'::bytea),
+    (E'set\\000member2'::bytea),
+    (E'set\\000member3'::bytea);
+
+select length(member), member from db15_bytea_set order by member;
+
+delete from db15_bytea_set where member = E'set\\000member2'::bytea;
+
+select length(member), member from db15_bytea_set order by member;
+
+-- update member
+update db15_bytea_set set member = E'set\\000updated'::bytea where member = E'set\\000member1'::bytea;
+
+select length(member), member from db15_bytea_set order by member;
+
+delete from db15_bytea_set;
+
+select * from db15_bytea_set;
+
+-- singleton zset table with bytea member and scores
+create foreign table db15_bytea_zset(member bytea, score numeric)
+       server localredis
+       options (singleton_key 'bytea_zset', tabletype 'zset', database '15');
+
+select * from db15_bytea_zset;
+
+insert into db15_bytea_zset values
+    (E'zset\\000m1'::bytea, 1),
+    (E'zset\\000m2'::bytea, 2),
+    (E'zset\\000m3'::bytea, 3);
+
+select length(member), member, score from db15_bytea_zset order by score;
+
+delete from db15_bytea_zset where member = E'zset\\000m2'::bytea;
+
+select length(member), member, score from db15_bytea_zset order by score;
+
+update db15_bytea_zset set score = 10 where member = E'zset\\000m1'::bytea;
+
+select length(member), member, score from db15_bytea_zset order by score;
+
+delete from db15_bytea_zset;
+
+select * from db15_bytea_zset;
+
+-- non-singleton set table with bytea[] array column
+create foreign table db15_bytea_set_arr(key text, val bytea[])
+       server localredis
+       options (database '15', tabletype 'set', tablekeyprefix 'bset_');
+
+select * from db15_bytea_set_arr;
+
+insert into db15_bytea_set_arr values
+    ('bset_a', array[E'a\\000'::bytea, E'b\\000'::bytea, E'c\\000'::bytea]);
+
+select key, val from db15_bytea_set_arr order by key;
+
+delete from db15_bytea_set_arr;
+
+select * from db15_bytea_set_arr;
+
+-- non-singleton zset table with bytea[] array column
+create foreign table db15_bytea_zset_arr(key text, val bytea[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bzset_');
+
+select * from db15_bytea_zset_arr;
+
+insert into db15_bytea_zset_arr values
+    ('bzset_a', array[E'x\\000'::bytea, E'y\\000'::bytea, E'z\\000'::bytea]);
+
+select key, val from db15_bytea_zset_arr order by key;
+
+delete from db15_bytea_zset_arr;
+
+select * from db15_bytea_zset_arr;
+
+-- singleton list table with bytea value
+-- note: UPDATE and DELETE not supported for list tables (Redis API limitation)
+create foreign table db15_bytea_list(val bytea)
+       server localredis
+       options (singleton_key 'bytea_list', tabletype 'list', database '15');
+
+select * from db15_bytea_list;
+
+insert into db15_bytea_list values
+    (E'list\\000item1'::bytea),
+    (E'list\\000item2'::bytea),
+    (E'list\\000item3'::bytea);
+
+select length(val), val from db15_bytea_list;
+
+-- clean up bytea tests
+\! redis-cli < test/sql/redis_clean
+

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -1359,11 +1359,8 @@ insert into db15_bytea_list values
 
 select length(val), val from db15_bytea_list;
 
--- regression test: bytea key column on a non-singleton table must be
--- rejected for DELETE too, not just INSERT/UPDATE. Before the fix, DELETE
--- skipped this check entirely and sent the escaped-text representation of
--- the key to Redis's DEL command instead of the real binary key, so the
--- delete would silently affect 0 keys while PostgreSQL reported success.
+-- a bytea key column on a non-singleton table is rejected for DELETE too,
+-- not just INSERT/UPDATE
 
 create foreign table db15_bytea_key_ns(key bytea, val text)
        server localredis
@@ -1373,11 +1370,8 @@ delete from db15_bytea_key_ns where key = E'anything'::bytea; -- bytea key error
 
 drop foreign table db15_bytea_key_ns;
 
--- regression test: updating a singleton set member to a bytea value that
--- already exists in the set must be rejected as a duplicate. Before the
--- fix, the pre-flight SISMEMBER check used a text sentinel ("") instead of
--- the real new member bytes, so it always reported "not found" and let the
--- update through regardless of whether the new value already existed.
+-- updating a singleton set member to a bytea value that already exists in
+-- the set is rejected as a duplicate
 
 create foreign table db15_bytea_set_dup(member bytea)
        server localredis

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -1359,6 +1359,42 @@ insert into db15_bytea_list values
 
 select length(val), val from db15_bytea_list;
 
+-- regression test: bytea key column on a non-singleton table must be
+-- rejected for DELETE too, not just INSERT/UPDATE. Before the fix, DELETE
+-- skipped this check entirely and sent the escaped-text representation of
+-- the key to Redis's DEL command instead of the real binary key, so the
+-- delete would silently affect 0 keys while PostgreSQL reported success.
+
+create foreign table db15_bytea_key_ns(key bytea, val text)
+       server localredis
+       options (database '15');
+
+delete from db15_bytea_key_ns where key = E'anything'::bytea; -- bytea key error
+
+drop foreign table db15_bytea_key_ns;
+
+-- regression test: updating a singleton set member to a bytea value that
+-- already exists in the set must be rejected as a duplicate. Before the
+-- fix, the pre-flight SISMEMBER check used a text sentinel ("") instead of
+-- the real new member bytes, so it always reported "not found" and let the
+-- update through regardless of whether the new value already existed.
+
+create foreign table db15_bytea_set_dup(member bytea)
+       server localredis
+       options (singleton_key 'bytea_set_dup', tabletype 'set', database '15');
+
+insert into db15_bytea_set_dup values
+    (E'dup\\000existing'::bytea), (E'other\\000member'::bytea);
+
+update db15_bytea_set_dup set member = E'dup\\000existing'::bytea
+       where member = E'other\\000member'::bytea; -- must fail: key already exists
+
+select length(member), member from db15_bytea_set_dup order by member;
+
+delete from db15_bytea_set_dup;
+
+drop foreign table db15_bytea_set_dup;
+
 -- clean up bytea tests
 \! redis-cli < test/sql/redis_clean
 

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -1168,6 +1168,82 @@ drop server aclsrv cascade;
 drop server aclbad cascade;
 
 \! redis-cli ACL DELUSER fdwtest > /dev/null
+-- A collection table stores its members in an array-typed value column. A
+-- scalar bytea column cannot hold them: unlike scalar text, which yields a
+-- PostgreSQL array literal that casts back to an array, bytea has no array
+-- literal form. The write path already refuses this shape; the read path
+-- must too, rather than silently returning an empty bytea.
+
+\! redis-cli -n 15 rpush bcol_list a b c > /dev/null
+\! redis-cli -n 15 sadd  bcol_set  x y   > /dev/null
+\! redis-cli -n 15 hset  bcol_hash f1 v1 > /dev/null
+\! redis-cli -n 15 zadd  bcol_zset 1 m1  > /dev/null
+
+create foreign table db15_bcol_list(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'list', tablekeyprefix 'bcol_list');
+
+select * from db15_bcol_list;
+
+-- the check must sit after the EXPLAIN early return: planning must not error
+explain (costs off) select * from db15_bcol_list;
+
+create foreign table db15_bcol_set(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'set', tablekeyprefix 'bcol_set');
+
+select * from db15_bcol_set;
+
+create foreign table db15_bcol_hash(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'hash', tablekeyprefix 'bcol_hash');
+
+select * from db15_bcol_hash;
+
+create foreign table db15_bcol_zset(key text, value bytea)
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bcol_zset');
+
+select * from db15_bcol_zset;
+
+-- bytea[] on the same table is the correct shape and must keep working
+create foreign table db15_bcol_list_arr(key text, value bytea[])
+       server localredis
+       options (database '15', tabletype 'list', tablekeyprefix 'bcol_list');
+
+select key, value from db15_bcol_list_arr;
+
+-- a singleton collection with a scalar bytea column is the feature's main
+-- use case and must keep working
+create foreign table db15_bcol_sing_set(member bytea)
+       server localredis
+       options (database '15', tabletype 'set', singleton_key 'bcol_set');
+
+select member from db15_bcol_sing_set order by member;
+
+create foreign table db15_bcol_sing_list(member bytea)
+       server localredis
+       options (database '15', tabletype 'list', singleton_key 'bcol_list');
+
+select member from db15_bcol_sing_list;
+
+-- a scalar table with a bytea value column must keep working
+\! redis-cli -n 15 set bcol_scalar_k hello > /dev/null
+
+create foreign table db15_bcol_scalar(key text, value bytea)
+       server localredis
+       options (database '15', tablekeyprefix 'bcol_scalar');
+
+select key, value from db15_bcol_scalar;
+
+drop foreign table db15_bcol_list;
+drop foreign table db15_bcol_set;
+drop foreign table db15_bcol_hash;
+drop foreign table db15_bcol_zset;
+drop foreign table db15_bcol_list_arr;
+drop foreign table db15_bcol_sing_set;
+drop foreign table db15_bcol_sing_list;
+drop foreign table db15_bcol_scalar;
 
 -- all done, so now blow everything in the db away again
 


### PR DESCRIPTION
## Summary
- Third and final PR of a 3-PR stack that restructures the previously-combined bytea-support change into separate refactor / optimization / feature PRs.
- Adds support for `bytea` columns for storing binary data, including data with embedded NUL bytes, using Redis's binary-safe commands. Supported for:
  - Scalar tables (singleton and non-singleton)
  - Hash tables (value column only, singleton)
  - Set tables (member column, `bytea[]` for non-singleton)
  - Zset tables (member column, `bytea[]` for non-singleton)
  - List tables (singleton, INSERT/SELECT only)
- Extends the `redis_val_type` classification and `get_datum_as_string()` helper (introduced in #50) with a `REDIS_VAL_BYTEA` case, adds per-column type/tuple-descriptor caching to the scan state, and builds tuples via `heap_form_tuple()` instead of `BuildTupleFromCStrings()` when a bytea or array column is present, so binary data survives the round trip through Redis intact.
- Includes README documentation and regression tests for the new `bytea` support.

## Dependency chain
1. `redis-command-refactor` — command-handling refactor — #49
2. `redis-string-optimize` — string-handling optimizations — #50
3. **This PR** — bytea column support (based on #50)

Each PR should be merged in order, into its parent branch.

## Test plan
- [x] `make installcheck` passes the full regression suite, including new bytea tests
- [x] Verified the resulting `redis_fdw.c` matches a conflict-free `git merge-tree` of `concache` + the original combined bytea commit