### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: PostgreSQL ${{ matrix.pg }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [14, 15, 16, 17, 18]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Remove any preinstalled PostgreSQL
+        run: sudo apt-get purge -y 'postgresql*' || true
+
+      - name: Add the PostgreSQL APT repository
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update
+
+      # Install PostgreSQL and Valkey from their standard release packages -
+      # only redis_fdw itself is built from source here. Valkey is the
+      # actively-developed, license-compatible fork of Redis; libhiredis
+      # still works against it since Valkey speaks the same RESP wire
+      # protocol, and valkey-redis-compat provides the redis-cli symlink
+      # our test scripts use.
+      - name: Remove any preinstalled Redis
+        run: sudo apt-get purge -y 'redis-*' || true
+
+      - name: Install PostgreSQL ${{ matrix.pg }}, Valkey, and hiredis
+        run: |
+          sudo apt-get install -y \
+            postgresql-${{ matrix.pg }} \
+            postgresql-server-dev-${{ matrix.pg }} \
+            postgresql-client-${{ matrix.pg }} \
+            valkey-server \
+            valkey-redis-compat \
+            libhiredis-dev
+
+      - name: Put the PostgreSQL binaries on PATH
+        run: echo "/usr/lib/postgresql/${{ matrix.pg }}/bin" >> "$GITHUB_PATH"
+
+      - name: Build redis_fdw
+        run: make
+
+      - name: Install redis_fdw
+        run: sudo env "PATH=$PATH" make install
+
+      - name: Allow local trust authentication for the test run
+        run: |
+          sudo tee /etc/postgresql/${{ matrix.pg }}/main/pg_hba.conf > /dev/null <<'EOF'
+          local   all             all                                     trust
+          host    all             all             127.0.0.1/32            trust
+          host    all             all             ::1/128                 trust
+          EOF
+          sudo pg_ctlcluster ${{ matrix.pg }} main restart
+
+      - name: Create a superuser role for the CI user
+        run: sudo -u postgres createuser -s "$(whoami)"
+
+      - name: Confirm Valkey is available
+        run: |
+          valkey-cli ping
+          redis-cli ping
+
+      - name: Run regression tests
+        run: make installcheck || { cat test/regression.diffs; exit 1; }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that builds and regression-tests `redis_fdw` against each supported major PostgreSQL version (14-18).
- Addresses @dpage's review feedback on #45/#47:
  - PostgreSQL and Valkey are installed from their standard release packages (the official `apt.postgresql.org` PGDG repo for PostgreSQL, Ubuntu's repo for Valkey/hiredis) — nothing but `redis_fdw` itself is built from source.
  - The test matrix is keyed only on PostgreSQL **major** version (14, 15, 16, 17, 18), so it never needs updating for minor releases, and no test files are tied to specific minor versions.
- Tests against **Valkey** rather than Redis (Valkey is the actively-developed, license-compatible fork; `libhiredis` works against it unchanged since it's the same RESP wire protocol, and `valkey-redis-compat` supplies the `redis-cli` symlink our existing test scripts invoke, so no test-file changes were needed).
- Uses `actions/checkout@v7` (current latest; v4 is pinned to the now-deprecated Node 20 runtime).
- Deliberately excludes the postgis/GIS test scaffolding from #47, which isn't relevant to a Redis/Valkey FDW.

## Validation
Before opening this PR, the workflow was pushed to a throwaway personal repo and run for real (not just written blind):
- All 5 PostgreSQL major versions (14-18) passed against Valkey, with no warnings, across two iterations (initial Redis-based version, then switched to Valkey, then bumped checkout to v7).
- The scratch repo has been deleted now that this is confirmed working.

## Test plan
- [x] `PostgreSQL 14` job passes
- [x] `PostgreSQL 15` job passes
- [x] `PostgreSQL 16` job passes
- [x] `PostgreSQL 17` job passes
- [x] `PostgreSQL 18` job passes