### PR TITLE
Support Redis ACL username+password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Usage
 `redis_fdw` accepts the following options via the `CREATE USER MAPPING`
 command:
 
+- **username** as *string*, optional, no default
+
+  The username to authenticate to the Redis server with, for servers using
+  Redis ACLs (`AUTH username password`). If omitted, the legacy
+  password-only form (`AUTH password`) is used. Requires **password**: a
+  username on its own is rejected, since authentication is only attempted
+  when a password is present.
+
 - **password** as *string*, no default
 
   The password to authenticate to the Redis server with.
@@ -246,6 +254,19 @@ Where `pguser` is a sample user for works with foreign server (and foreign table
 	CREATE USER MAPPING FOR pguser
 	SERVER redis_server
 	OPTIONS (
+	  password 'secret'
+	);
+```
+
+If the Redis server uses ACLs, a `username` option can be supplied alongside
+`password` to authenticate as a specific ACL user instead of the default
+user:
+
+```sql
+	CREATE USER MAPPING FOR pguser
+	SERVER redis_server
+	OPTIONS (
+	  username 'redisuser',
 	  password 'secret'
 	);
 ```

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -103,6 +103,7 @@ static struct RedisFdwOption valid_options[] =
 	/* Connection options */
 	{"address", ForeignServerRelationId},
 	{"port", ForeignServerRelationId},
+	{"username", UserMappingRelationId},
 	{"password", UserMappingRelationId},
 
 	/* table options */
@@ -140,6 +141,7 @@ typedef struct redisTableOptions
 {
 	char	   *address;
 	int			port;
+	char	   *username;
 	char	   *password;
 	int			database;
 	char	   *keyprefix;
@@ -229,6 +231,7 @@ typedef struct RedisConnCacheKey
 {
 	char		address[256];
 	int			port;
+	char		username[256];
 	char		password[256];
 	int			database;
 } RedisConnCacheKey;
@@ -375,6 +378,8 @@ static void redis_conn_cache_cleanup(int code, Datum arg);
 static void redis_conn_cache_invalidate_callback(Datum arg, int cacheid, uint32 hashvalue);
 static void redis_build_cache_key(RedisConnCacheKey *key, redisTableOptions *options);
 static bool redis_validate_connection(redisContext *context);
+static redisReply *redis_authenticate(redisContext *context,
+						const char *username, const char *password);
 static redisContext *redis_get_connection(redisTableOptions *options);
 static RedisConnCacheEntry *redis_find_cache_entry(redisContext *context);
 static void redis_discard_connection(redisContext *context);
@@ -622,6 +627,9 @@ redis_build_cache_key(RedisConnCacheKey *key, redisTableOptions *options)
 
 	key->port = options->port ? options->port : 6379;
 
+	if (options->username)
+		strlcpy(key->username, options->username, sizeof(key->username));
+
 	if (options->password)
 		strlcpy(key->password, options->password, sizeof(key->password));
 
@@ -653,6 +661,30 @@ redis_validate_connection(redisContext *context)
 		freeReplyObject(reply);
 
 	return valid;
+}
+
+/*
+ * redis_authenticate
+ *		Send the Redis AUTH command, binary-safely. Uses the ACL
+ *		"AUTH username password" form when a username is supplied,
+ *		otherwise falls back to the legacy "AUTH password" form.
+ */
+static redisReply *
+redis_authenticate(redisContext *context, const char *username, const char *password)
+{
+	size_t		password_len = strlen(password);
+
+	if (username)
+		return redis_command_impl(context, "AUTH", sizeof("AUTH") - 1,
+								  username, strlen(username),
+								  NULL, 0, password, password_len);
+	else
+	{
+		const char *argv[2] = {"AUTH", password};
+		size_t		argvlen[2] = {sizeof("AUTH") - 1, password_len};
+
+		return redisCommandArgv(context, 2, argv, argvlen);
+	}
 }
 
 /*
@@ -719,7 +751,7 @@ redis_get_connection(redisTableOptions *options)
 
 	if (options->password)
 	{
-		reply = redisCommand(context, "AUTH %s", options->password);
+		reply = redis_authenticate(context, options->username, options->password);
 
 		if (!reply)
 		{
@@ -863,6 +895,7 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 	Oid			catalog = PG_GETARG_OID(1);
 	char	   *svr_address = NULL;
 	int			svr_port = 0;
+	char	   *svr_username = NULL;
 	char	   *svr_password = NULL;
 	int			svr_database = 0;
 	redis_table_type tabletype = PG_REDIS_SCALAR_TABLE;
@@ -937,6 +970,15 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 								));
 
 			svr_password = defGetString(def);
+		}
+		else if (strcmp(def->defname, "username") == 0)
+		{
+			if (svr_username)
+				ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("conflicting or redundant options: username")
+								));
+
+			svr_username = defGetString(def);
 		}
 		else if (strcmp(def->defname, "database") == 0)
 		{
@@ -1049,6 +1091,16 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 		}
 	}
 
+	/*
+	 * Authentication is only attempted when a password is present, so a
+	 * username on its own would be silently ignored and the connection made
+	 * unauthenticated - the opposite of what setting it implies.
+	 */
+	if (svr_username && !svr_password)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("option \"username\" requires option \"password\"")));
+
 	PG_RETURN_VOID();
 }
 
@@ -1094,6 +1146,7 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 	/* Set void values */
 	table_options->address = NULL;
 	table_options->port = 0;
+	table_options->username = NULL;
 	table_options->password = NULL;
 	table_options->database = 0;
 	table_options->keyprefix = NULL;
@@ -1127,6 +1180,9 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 
 		if (strcmp(def->defname, "password") == 0)
 			table_options->password = defGetString(def);
+
+		if (strcmp(def->defname, "username") == 0)
+			table_options->username = defGetString(def);
 
 		if (strcmp(def->defname, "database") == 0)
 			table_options->database = atoi(defGetString(def));

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1651,6 +1651,67 @@ select value from db15_conntest;
 
 commit;
 drop foreign table db15_conntest;
+-- A username with no password must be rejected. Authentication is gated on
+-- the password being set, so accepting a lone username would silently connect
+-- unauthenticated while the operator believed ACL auth was configured.
+create server authtest foreign data wrapper redis_fdw;
+create user mapping for public server authtest options (username 'u');
+ERROR:  option "username" requires option "password"
+-- both together are fine
+create user mapping for public server authtest options (username 'u', password 'p');
+-- and dropping just the password must be rejected too
+alter user mapping for public server authtest options (drop password);
+ERROR:  option "username" requires option "password"
+drop user mapping for public server authtest;
+-- the legacy password-only form is still accepted
+create user mapping for public server authtest options (password 'p');
+drop user mapping for public server authtest;
+drop server authtest;
+-- ACL authentication end to end. The suite's default Redis user is
+-- unauthenticated, so the test can provision its own ACL user. "reset" makes
+-- the setup idempotent: a plain SETUSER merges into an existing user rather
+-- than replacing it, so a run that aborted before cleaning up would otherwise
+-- leave a user with two passwords and stale rules.
+\! redis-cli ACL SETUSER fdwtest reset on '>secret' '~*' '+@all' > /dev/null
+\! redis-cli -n 15 set acltest_k hello > /dev/null
+create server aclsrv foreign data wrapper redis_fdw;
+create user mapping for public server aclsrv
+       options (username 'fdwtest', password 'secret');
+create foreign table db15_acl(key text, value text)
+       server aclsrv
+       options (database '15', tablekeyprefix 'acltest_');
+select * from db15_acl order by key;
+    key    | value 
+-----------+-------
+ acltest_k | hello
+(1 row)
+
+-- A wrong password must be refused. This is the case that carries the weight:
+-- were AUTH skipped altogether, the connection would fall back to the
+-- unauthenticated default user and the query would succeed. The message comes
+-- from the server and is not a stable contract, so assert only the failure.
+create server aclbad foreign data wrapper redis_fdw;
+create user mapping for public server aclbad
+       options (username 'fdwtest', password 'wrongpw');
+create foreign table db15_aclbad(key text, value text)
+       server aclbad
+       options (database '15', tablekeyprefix 'acltest_');
+do $$
+begin
+  perform * from db15_aclbad;
+  raise notice 'unexpectedly connected with a bad password';
+exception when others then
+  raise notice 'authentication refused as expected';
+end
+$$;
+NOTICE:  authentication refused as expected
+drop foreign table db15_acl;
+drop foreign table db15_aclbad;
+drop server aclsrv cascade;
+NOTICE:  drop cascades to user mapping for public on server aclsrv
+drop server aclbad cascade;
+NOTICE:  drop cascades to user mapping for public on server aclbad
+\! redis-cli ACL DELUSER fdwtest > /dev/null
 -- all done, so now blow everything in the db away again
 \! redis-cli < test/sql/redis_clean
 OK

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -1096,6 +1096,79 @@ commit;
 
 drop foreign table db15_conntest;
 
+-- A username with no password must be rejected. Authentication is gated on
+-- the password being set, so accepting a lone username would silently connect
+-- unauthenticated while the operator believed ACL auth was configured.
+
+create server authtest foreign data wrapper redis_fdw;
+
+create user mapping for public server authtest options (username 'u');
+
+-- both together are fine
+create user mapping for public server authtest options (username 'u', password 'p');
+
+-- and dropping just the password must be rejected too
+alter user mapping for public server authtest options (drop password);
+
+drop user mapping for public server authtest;
+
+-- the legacy password-only form is still accepted
+create user mapping for public server authtest options (password 'p');
+
+drop user mapping for public server authtest;
+
+drop server authtest;
+
+-- ACL authentication end to end. The suite's default Redis user is
+-- unauthenticated, so the test can provision its own ACL user. "reset" makes
+-- the setup idempotent: a plain SETUSER merges into an existing user rather
+-- than replacing it, so a run that aborted before cleaning up would otherwise
+-- leave a user with two passwords and stale rules.
+
+\! redis-cli ACL SETUSER fdwtest reset on '>secret' '~*' '+@all' > /dev/null
+\! redis-cli -n 15 set acltest_k hello > /dev/null
+
+create server aclsrv foreign data wrapper redis_fdw;
+
+create user mapping for public server aclsrv
+       options (username 'fdwtest', password 'secret');
+
+create foreign table db15_acl(key text, value text)
+       server aclsrv
+       options (database '15', tablekeyprefix 'acltest_');
+
+select * from db15_acl order by key;
+
+-- A wrong password must be refused. This is the case that carries the weight:
+-- were AUTH skipped altogether, the connection would fall back to the
+-- unauthenticated default user and the query would succeed. The message comes
+-- from the server and is not a stable contract, so assert only the failure.
+
+create server aclbad foreign data wrapper redis_fdw;
+
+create user mapping for public server aclbad
+       options (username 'fdwtest', password 'wrongpw');
+
+create foreign table db15_aclbad(key text, value text)
+       server aclbad
+       options (database '15', tablekeyprefix 'acltest_');
+
+do $$
+begin
+  perform * from db15_aclbad;
+  raise notice 'unexpectedly connected with a bad password';
+exception when others then
+  raise notice 'authentication refused as expected';
+end
+$$;
+
+drop foreign table db15_acl;
+drop foreign table db15_aclbad;
+drop server aclsrv cascade;
+drop server aclbad cascade;
+
+\! redis-cli ACL DELUSER fdwtest > /dev/null
+
 -- all done, so now blow everything in the db away again
 
 \! redis-cli < test/sql/redis_clean


### PR DESCRIPTION
## Summary
- Adds a `username` user-mapping option so servers using Redis ACLs can authenticate as a specific user via `AUTH username password`, instead of only the legacy `AUTH password` form against the default user.
- Built on top of the connection-cache work (#48/redis-string-optimize): the single `redis_get_connection()` authentication call site is extended via a new `redis_authenticate()` helper (built on the binary-safe `redis_command_impl()`), rather than duplicating username-handling across the three separate connect/auth blocks that existed pre-connection-cache on master.
- The connection cache key is extended with `username` so distinct credentials get distinct cached connections.
- Based on the idea proposed by @TheGreatRefrigerator in #41, reimplemented here against the current connection-cache architecture rather than incorporating that patch directly (which predates the connection cache and duplicated the auth logic three times).

## Dependency
This targets `redis-string-optimize` (#50), which targets `redis-command-refactor` (#49), which targets `concache` (#48). Should be merged after that stack, in order.

## Validation
- Full regression suite passes.
- End-to-end tested against a live Valkey instance with Redis ACLs:
  - Correct `username`+`password` succeeds.
  - Wrong password is now correctly rejected (`WRONGPASS invalid username-password pair...`) — this also surfaced and fixed a latent bug where auth failures were silently ignored (the old code only checked for a NULL reply, not a `REDIS_REPLY_ERROR` reply).
  - Legacy password-only auth (no username) still works.

## Test plan
- [x] Full regression suite passes
- [x] ACL auth with correct username+password succeeds
- [x] ACL auth with wrong password is rejected with a clear error
- [x] Legacy password-only auth still works