### PR TITLE
Support reading zset scores via an optional 3rd scores array column

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,35 @@ Structured items are returned as `array text`, or, if the value column is a
 text array as an array of values. In the case of hash objects this array is
 an array of key, value, key, value ...
 
-Non-singleton `zset` tables may optionally declare a third column, of type
-`numeric[]`, to receive the score for each member in the value array, in
-the same order (i.e. `scores[i]` is the score of `value[i]`). This column
-is read-only; `INSERT`/`UPDATE` still require exactly the `key`/`value`
-columns.
+Non-singleton `zset` tables may optionally declare a third column, an array
+type, to hold the score of each member in the value array, in the same order
+(i.e. `scores[i]` is the score of `value[i]`). Any element type whose text
+output is a valid Redis float works; `numeric[]`, `float8[]` and `text[]` are
+all accepted.
+
+The column is writable. `INSERT` and `UPDATE` must supply the members and
+scores arrays together, and the two must have the same length:
+
+```sql
+	INSERT INTO ztab VALUES ('key', '{a,b,c}', '{10,20,30}');
+	UPDATE ztab SET value = '{a,b,d}', scores = '{10,20,40}' WHERE key = 'key';
+```
+
+A zset is a Redis object, not an array: reading it back returns members in
+score order, not the order they were written in, and a member written more
+than once in the same call collapses to a single entry at its last score.
+`scores[i]` is the score of `value[i]` only at write time.
+
+Setting only one of the pair is an error. An `UPDATE` replaces the whole
+Redis key rather than merging into it, so the arrays supplied are the
+complete new contents; a partial update would have to invent the missing
+half, and inventing it from the values read earlier can silently revert a
+score another client changed in the meantime.
+
+`Infinity` and `-Infinity` are accepted as scores. `NaN` is not: PostgreSQL
+allows it in `numeric` and `float8`, but Redis rejects it, so the error comes
+from the server. The whole write is rejected before anything changes, so a
+row's previous members and scores are left exactly as they were.
 
 Singleton key tables are returned as rows with a single column of text
 in the case of lists sets and scalars, rows with key and value text columns

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Structured items are returned as `array text`, or, if the value column is a
 text array as an array of values. In the case of hash objects this array is
 an array of key, value, key, value ...
 
+Non-singleton `zset` tables may optionally declare a third column, of type
+`numeric[]`, to receive the score for each member in the value array, in
+the same order (i.e. `scores[i]` is the score of `value[i]`). This column
+is read-only; `INSERT`/`UPDATE` still require exactly the `key`/`value`
+columns.
+
 Singleton key tables are returned as rows with a single column of text
 in the case of lists sets and scalars, rows with key and value text columns
 for hashes, and rows with a value text columns and an optional numeric score

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -222,6 +222,10 @@ typedef struct RedisFdwModifyState
 	int			p_nums;
 	int			keyAttno;
 	Oid			array_elem_type;
+	bool		with_scores;	/* non-singleton zset table with a 3rd
+								 * scores-array column */
+	Oid			scores_elem_type;	/* element type of that scores array */
+	int			scores_pidx;	/* its index in p_flinfo/val_types, or -1 */
 	FmgrInfo   *p_flinfo;
 	redis_val_type *val_types;	/* column value type categories */
 } RedisFdwModifyState;
@@ -230,6 +234,21 @@ typedef struct RedisFdwModifyState
 #define ZERO "0"
 /* redis default is 10 - let's fetch 1000 at a time */
 #define COUNT " COUNT 1000"
+
+/*
+ * Prefix for the staging key a zset UPDATE rebuilds into before swapping it
+ * in with RENAME (see redisExecForeignUpdate).  The backend pid is folded
+ * into the key (built at the use site) so concurrent updates of the same
+ * row use different staging keys rather than racing to reuse one.
+ *
+ * The prefix goes in front rather than behind the real key name so it can
+ * never satisfy a tablekeyprefix- or tablekeyset-restricted scan for that
+ * key.  It is not hidden from a plain, unrestricted scan: a table with
+ * neither option walks the whole keyspace with SCAN, and the staging key is
+ * a real zset, so such a scan can return it as a row for the moment it
+ * exists.
+ */
+#define ZSET_REBUILD_PREFIX "\x01redis_fdw_zset_rebuild\x01"
 
 /*
  * Connection cache structures
@@ -2828,6 +2847,24 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 
 	array_elem_list = (List *) list_nth(fdw_private, 1);
 	fmstate->array_elem_type = list_nth_oid(array_elem_list, 0);
+	fmstate->with_scores =
+		redis_zset_has_scores_column(fmstate->table_type,
+									 fmstate->singleton_key,
+									 RelationGetDescr(rel)->natts);
+	fmstate->scores_elem_type = InvalidOid;
+	fmstate->scores_pidx = -1;
+
+	/*
+	 * The scores column's shape is known from the relation descriptor
+	 * alone, so check it here rather than per row: a scalar column would
+	 * otherwise reach DatumGetArrayTypeP() as though it were an array.
+	 */
+	if (fmstate->with_scores &&
+		TupleDescAttr(RelationGetDescr(rel), 2)->attndims == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("scores column must be an array")
+				 ));
 
 	fmstate->p_nums = 0;
 
@@ -2929,6 +2966,13 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 			fmstate->targetDims[fmstate->p_nums] = attr->attndims;
 			getTypeOutputInfo(elem, &typefnoid, &isvarlena);
 			fmgr_info(typefnoid, &fmstate->p_flinfo[fmstate->p_nums]);
+
+			if (fmstate->with_scores && attnum == 3)
+			{
+				fmstate->scores_pidx = fmstate->p_nums;
+				fmstate->scores_elem_type = elem;
+			}
+
 			fmstate->p_nums++;
 		}
 	}
@@ -3396,6 +3440,10 @@ redisExecForeignInsert(EState *estate,
 		redis_val_type elem_valtype;
 		bool		is_array = fmstate->array_elem_type != InvalidOid;
 		Datum		value = slot_getattr(slot, 2, &isnull);
+		Datum	   *score_elements = NULL;
+		bool	   *score_nulls = NULL;
+		int			nscores = 0;
+		redis_val_type score_valtype = REDIS_VAL_OTHER;
 
 		/* For non-singleton, get keyval for prefix checks and error messages */
 		keyval = OutputFunctionCall(&fmstate->p_flinfo[0], key);
@@ -3486,6 +3534,44 @@ redisExecForeignInsert(EState *estate,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("cannot insert NULL into a Redis table")
 							 ));
+			}
+
+			if (fmstate->with_scores)
+			{
+				bool		snull;
+				Datum		sval = slot_getattr(slot, 3, &snull);
+				int16		stlen;
+				bool		stbyval;
+				char		stalign;
+				int			si;
+
+				if (snull)
+					ereport(ERROR,
+							(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+							 errmsg("cannot insert NULL into a Redis table"),
+							 errhint("A zset table's members and scores columns are written as a pair.")));
+
+				get_typlenbyvalalign(fmstate->scores_elem_type,
+									 &stlen, &stbyval, &stalign);
+				deconstruct_array(DatumGetArrayTypeP(sval),
+								  fmstate->scores_elem_type, stlen, stbyval,
+								  stalign, &score_elements, &score_nulls,
+								  &nscores);
+
+				if (nscores != nitems)
+					ereport(ERROR,
+							(errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR),
+							 errmsg("members and scores arrays must have the same length"),
+							 errdetail("members has %d elements, scores has %d",
+									   nitems, nscores)));
+
+				for (si = 0; si < nscores; si++)
+					if (score_nulls[si])
+						ereport(ERROR,
+								(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+								 errmsg("cannot insert NULL into a Redis table")));
+
+				score_valtype = classify_type(fmstate->scores_elem_type);
 			}
 		}
 
@@ -3589,24 +3675,55 @@ redisExecForeignInsert(EState *estate,
 					int			i;
 					int			ibuff_len;
 					char		ibuff[100];
+					int			zargc = 2 + 2 * nitems;
+					const char **zargv = (const char **) palloc(sizeof(char *) * zargc);
+					size_t	   *zargvlen = (size_t *) palloc(sizeof(size_t) * zargc);
+
+					zargv[0] = "ZADD";
+					zargvlen[0] = 4;
+					zargv[1] = key_data;
+					zargvlen[1] = key_len;
 
 					for (i = 0; i < nitems; i++)
 					{
 						const char *data;
 						size_t		len;
+						const char *score_data;
+						size_t		score_len;
 
-						ibuff_len = sprintf(ibuff, "%d", i);
+						if (fmstate->with_scores)
+							get_datum_as_string(score_elements[i], score_valtype,
+												&fmstate->p_flinfo[fmstate->scores_pidx],
+												&score_data, &score_len);
+						else
+						{
+							ibuff_len = sprintf(ibuff, "%d", i);
+							score_data = pnstrdup(ibuff, ibuff_len);
+							score_len = ibuff_len;
+						}
+
 						/* score comes BEFORE value in ZADD */
 						get_datum_as_string(elements[i], elem_valtype,
 											&fmstate->p_flinfo[1], &data, &len);
-						sreply = redis_command(context, "ZADD",
-											   key_data, key_len,
-											   ibuff, ibuff_len, data, len);
-						check_reply(sreply, context, RTYPE(REDIS_REPLY_INTEGER),
-									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
-									"could not add zset member", NULL);
-						freeReplyObject(sreply);
+
+						zargv[2 + 2 * i] = score_data;
+						zargvlen[2 + 2 * i] = score_len;
+						zargv[2 + 2 * i + 1] = data;
+						zargvlen[2 + 2 * i + 1] = len;
 					}
+
+					/*
+					 * All members go in a single ZADD: Redis parses every
+					 * score before adding any member, so an invalid score
+					 * fails the whole command and the key is never created,
+					 * instead of leaving a half-built key behind for the
+					 * retry to trip over.
+					 */
+					sreply = redisCommandArgv(context, zargc, zargv, zargvlen);
+					check_reply(sreply, context, RTYPE(REDIS_REPLY_INTEGER),
+								ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+								"could not add zset members", NULL);
+					freeReplyObject(sreply);
 				}
 				break;
 			default:
@@ -3759,6 +3876,12 @@ redisExecForeignUpdate(EState *estate,
 	/* For array updates */
 	Datum	   *array_elems = NULL;
 	redis_val_type array_elem_valtype = REDIS_VAL_OTHER;
+	bool		saw_members = false;
+	bool		saw_scores = false;
+	Datum	   *score_elements = NULL;
+	bool	   *score_nulls = NULL;
+	int			nscores = 0;
+	redis_val_type score_valtype = REDIS_VAL_OTHER;
 
 #ifdef DEBUG
 	elog(NOTICE, "redisExecForeignUpdate");
@@ -3779,6 +3902,33 @@ redisExecForeignUpdate(EState *estate,
 	newkey_len = key_len;
 
 	Assert(keyval != NULL);
+
+	if (fmstate->with_scores)
+	{
+		ListCell   *slc;
+
+		foreach(slc, fmstate->target_attrs)
+		{
+			int			a = lfirst_int(slc);
+
+			if (a == 2)
+				saw_members = true;
+			else if (a == 3)
+				saw_scores = true;
+		}
+
+		if (saw_members != saw_scores)
+		{
+			char	   *membname = NameStr(TupleDescAttr(RelationGetDescr(fmstate->rel), 1)->attname);
+			char	   *scorename = NameStr(TupleDescAttr(RelationGetDescr(fmstate->rel), 2)->attname);
+
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("updating \"%s\" or \"%s\" requires setting both",
+							membname, scorename),
+					 errhint("A zset table's members and scores columns are written as a pair.")));
+		}
+	}
 
 	/* extract the updated values */
 	foreach(lc, fmstate->target_attrs)
@@ -3836,6 +3986,20 @@ redisExecForeignUpdate(EState *estate,
 				newval_len = strlen(newval);
 			}
 		}
+		else if (fmstate->with_scores && attnum == 3)
+		{
+			int16		stlen;
+			bool		stbyval;
+			char		stalign;
+
+			get_typlenbyvalalign(fmstate->scores_elem_type,
+								 &stlen, &stbyval, &stalign);
+			deconstruct_array(DatumGetArrayTypeP(datum),
+							  fmstate->scores_elem_type, stlen, stbyval,
+							  stalign, &score_elements, &score_nulls,
+							  &nscores);
+			score_valtype = classify_type(fmstate->scores_elem_type);
+		}
 		else
 		{
 			/*
@@ -3885,6 +4049,13 @@ redisExecForeignUpdate(EState *estate,
 
 		flslot++;
 	}
+
+	if (fmstate->with_scores && saw_scores && nscores != nitems)
+		ereport(ERROR,
+				(errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR),
+				 errmsg("members and scores arrays must have the same length"),
+				 errdetail("members has %d elements, scores has %d",
+						   nitems, nscores)));
 
 	/* now we have all the data we need */
 
@@ -4252,7 +4423,102 @@ redisExecForeignUpdate(EState *estate,
 		freeReplyObject(ereply);
 	}
 
-	if (array_elems)
+	if (array_elems && fmstate->table_type == PG_REDIS_ZSET_TABLE)
+	{
+		/*
+		 * A zset rebuild cannot use the DEL-then-repopulate approach below:
+		 * unlike SADD/RPUSH/HSET, ZADD can reject one of the caller's own
+		 * arguments (an invalid score), and by that point the DEL would
+		 * already have destroyed the row it was rebuilding.  Build the new
+		 * contents in a private staging key instead, with a single ZADD --
+		 * Redis parses every score before touching the object, so a bad
+		 * score fails the whole command and never even reaches the staging
+		 * key -- and only swap it in with RENAME once that succeeds.
+		 * RENAME replaces the destination atomically, so this never runs a
+		 * command against newkey that could fail because of the caller's
+		 * data.
+		 */
+		int			i;
+		int			ibuff_len;
+		char		ibuff[100];
+		char		pidbuf[24];
+		int			pidlen;
+		char	   *stagingkey;
+		size_t		stagingkey_len;
+		int			zargc = 2 + 2 * nitems;
+		const char **zargv = (const char **) palloc(sizeof(char *) * zargc);
+		size_t	   *zargvlen = (size_t *) palloc(sizeof(size_t) * zargc);
+
+		Assert(!fmstate->singleton_key);
+
+		/*
+		 * Fold the backend pid into the staging key: without it, two
+		 * backends updating the same row would share one staging key, and
+		 * whichever ZADD ran last would win the RENAME with the other
+		 * backend's contents instead of its own.
+		 */
+		pidlen = snprintf(pidbuf, sizeof(pidbuf), "%d\x01", (int) MyProcPid);
+
+		stagingkey_len = strlen(ZSET_REBUILD_PREFIX) + pidlen + newkey_len;
+		stagingkey = palloc(stagingkey_len);
+		memcpy(stagingkey, ZSET_REBUILD_PREFIX, strlen(ZSET_REBUILD_PREFIX));
+		memcpy(stagingkey + strlen(ZSET_REBUILD_PREFIX), pidbuf, pidlen);
+		memcpy(stagingkey + strlen(ZSET_REBUILD_PREFIX) + pidlen, newkey_data, newkey_len);
+
+		/* clear any staging key a previous failed attempt left behind */
+		ereply = redis_command1(context, "DEL", stagingkey, stagingkey_len);
+		check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+					ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+					"could not clear staging key for %s", newkey);
+		freeReplyObject(ereply);
+
+		zargv[0] = "ZADD";
+		zargvlen[0] = 4;
+		zargv[1] = stagingkey;
+		zargvlen[1] = stagingkey_len;
+
+		for (i = 0; i < nitems; i++)
+		{
+			const char *data;
+			size_t		len;
+			const char *score_data;
+			size_t		score_len;
+
+			if (fmstate->with_scores)
+				get_datum_as_string(score_elements[i], score_valtype,
+									&fmstate->p_flinfo[fmstate->scores_pidx],
+									&score_data, &score_len);
+			else
+			{
+				ibuff_len = sprintf(ibuff, "%d", i);
+				score_data = pnstrdup(ibuff, ibuff_len);
+				score_len = ibuff_len;
+			}
+
+			/* score comes BEFORE value in ZADD */
+			get_datum_as_string(array_elems[i], array_elem_valtype,
+								&fmstate->p_flinfo[1], &data, &len);
+
+			zargv[2 + 2 * i] = score_data;
+			zargvlen[2 + 2 * i] = score_len;
+			zargv[2 + 2 * i + 1] = data;
+			zargvlen[2 + 2 * i + 1] = len;
+		}
+
+		ereply = redisCommandArgv(context, zargc, zargv, zargvlen);
+		check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+					ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+					"could not add zset members", NULL);
+		freeReplyObject(ereply);
+
+		ereply = redis_command2(context, "RENAME", stagingkey, stagingkey_len,
+								newkey_data, newkey_len);
+		check_reply(ereply, context, RTYPE(REDIS_REPLY_STATUS),
+					ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+					"could not replace key %s", newkey);
+		freeReplyObject(ereply);
+	}
+	else if (array_elems)
 	{
 		Assert(!fmstate->singleton_key);
 
@@ -4341,31 +4607,6 @@ redisExecForeignUpdate(EState *estate,
 						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
 									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 									"could not add hash field", NULL);
-						freeReplyObject(ereply);
-					}
-				}
-				break;
-			case PG_REDIS_ZSET_TABLE:
-				{
-					int			i;
-					int			ibuff_len;
-					char		ibuff[100];
-
-					for (i = 0; i < nitems; i++)
-					{
-						const char *data;
-						size_t		len;
-
-						ibuff_len = sprintf(ibuff, "%d", i);
-						/* score comes BEFORE value in ZADD */
-						get_datum_as_string(array_elems[i], array_elem_valtype,
-											&fmstate->p_flinfo[1], &data, &len);
-						ereply = redis_command(context, "ZADD",
-											   newkey_data, newkey_len,
-											   ibuff, ibuff_len, data, len);
-						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
-									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
-									"could not add zset member", NULL);
 						freeReplyObject(ereply);
 					}
 				}

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -380,6 +380,8 @@ static redisReply *redis_command2_impl(redisContext *context,
 #define redis_command2(ctx, cmd, arg1, arg1_len, arg2, arg2_len) \
 	redis_command2_impl(ctx, cmd, sizeof(cmd) - 1, arg1, arg1_len, arg2, arg2_len)
 static inline redis_val_type classify_type(Oid typid);
+static inline bool redis_zset_has_scores_column(redis_table_type table_type,
+									const char *singleton_key, int natts);
 static void get_datum_as_string(Datum datum, redis_val_type valtype,
 						FmgrInfo *flinfo, const char **data, size_t *len);
 
@@ -1566,9 +1568,9 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 	 * a parallel array of scores, alongside the usual key and members-array
 	 * columns.
 	 */
-	festate->with_scores = (festate->table_type == PG_REDIS_ZSET_TABLE &&
-							!festate->singleton_key &&
-							node->ss.ss_currentRelation->rd_att->natts == 3);
+	festate->with_scores = redis_zset_has_scores_column(festate->table_type,
+														 festate->singleton_key,
+														 node->ss.ss_currentRelation->rd_att->natts);
 
 	festate->qual_value = pushdown ? qual_value : NULL;
 
@@ -2953,12 +2955,19 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 						 errmsg("table has incorrect number of columns: %d for type %d", fmstate->p_nums, table_options.table_type)
 						 ));
 		}
-		else if (fmstate->p_nums != 2)
+		else
 		{
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("table has incorrect number of columns")
-					 ));
+			int			expected_cols;
+
+			expected_cols = redis_zset_has_scores_column(table_options.table_type,
+														  table_options.singleton_key,
+														  RelationGetDescr(rel)->natts) ? 3 : 2;
+
+			if (fmstate->p_nums != expected_cols)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("table has incorrect number of columns")
+						 ));
 		}
 	}
 	else if (op == CMD_UPDATE)
@@ -3150,6 +3159,21 @@ classify_type(Oid typid)
 		default:
 			return REDIS_VAL_OTHER;
 	}
+}
+
+/*
+ * redis_zset_has_scores_column
+ *		A non-singleton zset table may declare a 3rd column holding a
+ *		parallel array of member scores, alongside the usual key and
+ *		members-array columns.
+ */
+static inline bool
+redis_zset_has_scores_column(redis_table_type table_type,
+							  const char *singleton_key, int natts)
+{
+	return table_type == PG_REDIS_ZSET_TABLE &&
+		!singleton_key &&
+		natts == 3;
 }
 
 /*

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -197,6 +197,9 @@ typedef struct RedisFdwExecutionState
 	int			natts;			/* number of attributes */
 	TupleDesc	tupdesc;		/* cached tuple descriptor */
 	Oid			array_elem_type;	/* element type if value column is array */
+	Oid			scores_elem_type;	/* element type of the scores column */
+	bool		with_scores;	/* non-singleton zset table has a 3rd
+								 * (scores array) column */
 } RedisFdwExecutionState;
 
 typedef struct RedisFdwModifyState
@@ -355,8 +358,9 @@ static char *redis_escape_glob(const char *str);
 #define RTYPE(t)	(1 << (t))
 #define RTYPE_ANY	0
 
-static char *redis_array_to_text(redisReply *reply);
-static Datum process_redis_array(redisReply *reply, Oid elem_type);
+static char *redis_array_to_text(redisReply *reply, int offset, int stride);
+static Datum process_redis_array(redisReply *reply, Oid elem_type,
+								 int offset, int stride);
 static void check_reply(redisReply *reply, redisContext *context,
 						int allowed, int error_code, char *message, char *arg);
 static redisReply *redis_command_impl(redisContext *context,
@@ -1557,6 +1561,15 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 	festate->cursor_id = NULL;
 	festate->cursor_search_string = NULL;
 
+	/*
+	 * A non-singleton zset table may optionally have a 3rd column holding
+	 * a parallel array of scores, alongside the usual key and members-array
+	 * columns.
+	 */
+	festate->with_scores = (festate->table_type == PG_REDIS_ZSET_TABLE &&
+							!festate->singleton_key &&
+							node->ss.ss_currentRelation->rd_att->natts == 3);
+
 	festate->qual_value = pushdown ? qual_value : NULL;
 
 	/* OK, we connected. If this is an EXPLAIN, bail out now */
@@ -1583,6 +1596,19 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 	{
 		Form_pg_attribute attr = TupleDescAttr(festate->tupdesc, 1);
 		festate->array_elem_type = get_element_type(attr->atttypid);
+	}
+
+	/*
+	 * The scores column, when the table declares one. Its element type is
+	 * whatever the user declared - numeric[] in the usual case - so the
+	 * decoder needs it to know which input function to use.
+	 */
+	festate->scores_elem_type = InvalidOid;
+	if (festate->with_scores && festate->natts >= 3)
+	{
+		Form_pg_attribute sattr = TupleDescAttr(festate->tupdesc, 2);
+
+		festate->scores_elem_type = get_element_type(sattr->atttypid);
 	}
 
 	/*
@@ -1825,11 +1851,13 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 	char	   *key;
 	char	   *data = 0;
 	size_t		data_len = 0;
+	char	   *scores = 0;
 	char	  **values;
 	HeapTuple	tuple;
 	bool		has_bytea = false;
 	bool		has_array = false;
 	Datum		array_datum = (Datum) 0;
+	Datum		scores_datum = (Datum) 0;
 
 	RedisFdwExecutionState *festate = (RedisFdwExecutionState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
@@ -1981,8 +2009,12 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 										 "SMEMBERS %s", key);
 					break;
 				case PG_REDIS_ZSET_TABLE:
-					reply = redisCommand(festate->context,
-										 "ZRANGE %s 0 -1", key);
+					if (festate->with_scores)
+						reply = redisCommand(festate->context,
+											 "ZRANGE %s 0 -1 WITHSCORES", key);
+					else
+						reply = redisCommand(festate->context,
+											 "ZRANGE %s 0 -1", key);
 					break;
 				case PG_REDIS_SCALAR_TABLE:
 				default:
@@ -2030,10 +2062,26 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 					break;
 
 				case REDIS_REPLY_ARRAY:
-					if (has_array)
-						array_datum = process_redis_array(reply, festate->array_elem_type);
-					else
-						data = redis_array_to_text(reply);
+					{
+						int			stride = festate->with_scores ? 2 : 1;
+
+						if (has_array)
+							array_datum = process_redis_array(reply,
+															  festate->array_elem_type,
+															  0, stride);
+						else
+							data = redis_array_to_text(reply, 0, stride);
+
+						if (festate->with_scores)
+						{
+							if (festate->scores_elem_type != InvalidOid)
+								scores_datum = process_redis_array(reply,
+																   festate->scores_elem_type,
+																   1, 2);
+							else
+								scores = redis_array_to_text(reply, 1, 2);
+						}
+					}
 					found = true;
 					break;
 			}
@@ -2047,7 +2095,7 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 	/* Build the tuple */
 	if (found)
 	{
-		if (has_bytea || has_array)
+		if (has_bytea || has_array || festate->with_scores)
 		{
 			/* Use heap_form_tuple for bytea or array columns */
 			Datum	   *datums;
@@ -2071,12 +2119,36 @@ redisIterateForeignScanMulti(ForeignScanState *node)
 			{
 				nulls[1] = true;
 			}
-			else
+			else if (has_bytea)
 			{
 				bytea	   *bval = (bytea *) palloc(data_len + VARHDRSZ);
 				SET_VARSIZE(bval, data_len + VARHDRSZ);
 				memcpy(VARDATA(bval), data, data_len);
 				datums[1] = PointerGetDatum(bval);
+			}
+			else
+			{
+				/*
+				 * with_scores can reach here with a scalar text members
+				 * column, which must not be built as a bytea.
+				 */
+				datums[1] = CStringGetTextDatum(data);
+			}
+
+			/* Column 2: scores, when the table declares one */
+			if (festate->with_scores && festate->natts >= 3)
+			{
+				if (festate->scores_elem_type != InvalidOid)
+				{
+					if (scores_datum == (Datum) 0)
+						nulls[2] = true;
+					else
+						datums[2] = scores_datum;
+				}
+				else if (scores == NULL)
+					nulls[2] = true;
+				else
+					datums[2] = CStringGetTextDatum(scores);
 			}
 
 			tuple = heap_form_tuple(festate->tupdesc, datums, nulls);
@@ -2383,18 +2455,45 @@ redisGetQual(Node *node, TupleDesc tupdesc, char **key, char **value, bool *push
 }
 
 /*
+ * append_quoted_array_element
+ *		Append str (of length len) to buf as a double-quoted,
+ *		backslash-escaped PostgreSQL array literal element.
+ */
+static void
+append_quoted_array_element(StringInfo buf, const char *str, int len)
+{
+	char	   *quoted;
+	char	   *crs;
+
+	pg_verifymbstr(str, len, false);
+	quoted = palloc(len * 2 + 3);
+	crs = quoted;
+	*crs++ = '"';
+	for (int j = 0; j < len; j++)
+	{
+		if (str[j] == '"' || str[j] == '\\')
+			*crs++ = '\\';
+		*crs++ = str[j];
+	}
+	*crs++ = '"';
+	*crs = '\0';
+	appendStringInfoString(buf, quoted);
+	pfree(quoted);
+}
+
+/*
  * redis_array_to_text
  *		Convert a Redis array reply to a PostgreSQL array literal string.
  *		Used for scalar text columns that receive array data from Redis.
  */
 static char *
-redis_array_to_text(redisReply *reply)
+redis_array_to_text(redisReply *reply, int offset, int stride)
 {
 	StringInfo	res = makeStringInfo();
 	bool		need_sep = false;
 
 	appendStringInfoChar(res, '{');
-	for (int i = 0; i < reply->elements; i++)
+	for (int i = offset; i < reply->elements; i += stride)
 	{
 		redisReply *ir = reply->element[i];
 
@@ -2411,25 +2510,7 @@ redis_array_to_text(redisReply *reply)
 		{
 			case REDIS_REPLY_STATUS:
 			case REDIS_REPLY_STRING:
-				{
-					char	   *buff;
-					char	   *crs;
-
-					pg_verifymbstr(ir->str, ir->len, false);
-					buff = palloc(ir->len * 2 + 3);
-					crs = buff;
-					*crs++ = '"';
-					for (int j = 0; j < ir->len; j++)
-					{
-						if (ir->str[j] == '"' || ir->str[j] == '\\')
-							*crs++ = '\\';
-						*crs++ = ir->str[j];
-					}
-					*crs++ = '"';
-					*crs = '\0';
-					appendStringInfoString(res, buff);
-					pfree(buff);
-				}
+				append_quoted_array_element(res, ir->str, ir->len);
 				break;
 			case REDIS_REPLY_INTEGER:
 				appendStringInfo(res, "%lld", ir->integer);
@@ -2453,19 +2534,39 @@ redis_array_to_text(redisReply *reply)
  *		For text, validates UTF-8 encoding.
  */
 static Datum
-process_redis_array(redisReply *reply, Oid elem_type)
+process_redis_array(redisReply *reply, Oid elem_type, int offset, int stride)
 {
 	Datum	   *elems;
-	int			nelems = reply->elements;
+	int			nelems = (reply->elements > offset)
+		? ((reply->elements - offset + stride - 1) / stride)
+		: 0;
+	int			n = 0;
 	ArrayType  *result;
 	bool		is_bytea = (elem_type == BYTEAOID);
+	bool		is_text = (elem_type == TEXTOID ||
+						   elem_type == VARCHAROID ||
+						   elem_type == BPCHAROID);
+	Oid			typinput = InvalidOid;
+	Oid			typioparam = InvalidOid;
+	FmgrInfo	inputproc;
 	int16		typlen;
 	bool		typbyval;
 	char		typalign;
 
+	/*
+	 * Redis hands every value back as text. text and bytea are converted
+	 * directly; any other element type has no route in but its own input
+	 * function, so look that up once rather than per element.
+	 */
+	if (!is_bytea && !is_text)
+	{
+		getTypeInputInfo(elem_type, &typinput, &typioparam);
+		fmgr_info(typinput, &inputproc);
+	}
+
 	elems = (Datum *) palloc(sizeof(Datum) * nelems);
 
-	for (int i = 0; i < nelems; i++)
+	for (int i = offset; i < reply->elements; i += stride, n++)
 	{
 		redisReply *ir = reply->element[i];
 
@@ -2484,12 +2585,19 @@ process_redis_array(redisReply *reply, Oid elem_type)
 
 					SET_VARSIZE(bval, ir->len + VARHDRSZ);
 					memcpy(VARDATA(bval), ir->str, ir->len);
-					elems[i] = PointerGetDatum(bval);
+					elems[n] = PointerGetDatum(bval);
+				}
+				else if (is_text)
+				{
+					pg_verifymbstr(ir->str, ir->len, false);
+					elems[n] = PointerGetDatum(cstring_to_text_with_len(ir->str, ir->len));
 				}
 				else
 				{
-					pg_verifymbstr(ir->str, ir->len, false);
-					elems[i] = PointerGetDatum(cstring_to_text_with_len(ir->str, ir->len));
+					char	   *val = pnstrdup(ir->str, ir->len);
+
+					elems[n] = InputFunctionCall(&inputproc, val, typioparam, -1);
+					pfree(val);
 				}
 				break;
 			case REDIS_REPLY_INTEGER:
@@ -2504,11 +2612,15 @@ process_redis_array(redisReply *reply, Oid elem_type)
 
 						SET_VARSIZE(bval, len + VARHDRSZ);
 						memcpy(VARDATA(bval), buf, len);
-						elems[i] = PointerGetDatum(bval);
+						elems[n] = PointerGetDatum(bval);
+					}
+					else if (is_text)
+					{
+						elems[n] = PointerGetDatum(cstring_to_text_with_len(buf, len));
 					}
 					else
 					{
-						elems[i] = PointerGetDatum(cstring_to_text_with_len(buf, len));
+						elems[n] = InputFunctionCall(&inputproc, buf, typioparam, -1);
 					}
 				}
 				break;
@@ -2520,12 +2632,16 @@ process_redis_array(redisReply *reply, Oid elem_type)
 					bytea	   *bval = (bytea *) palloc(VARHDRSZ);
 
 					SET_VARSIZE(bval, VARHDRSZ);
-					elems[i] = PointerGetDatum(bval);
+					elems[n] = PointerGetDatum(bval);
+				}
+				else if (is_text)
+				{
+					elems[n] = PointerGetDatum(cstring_to_text(""));
 				}
 				else
-				{
-					elems[i] = PointerGetDatum(cstring_to_text(""));
-				}
+					ereport(ERROR,
+							(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
+							 errmsg("unexpected NULL element in a Redis array reply")));
 				break;
 		}
 	}

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1214,6 +1214,20 @@ select * from db15_w_zset_pfx;
 -----+-----
 (0 rows)
 
+-- non-singleton zset table with a 3rd scores column: insert names only
+-- the key and value columns, leaving scores to be populated by Redis
+create foreign table db15_w_zset_pfx_scores(key text, val text[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'w_zset_');
+insert into db15_w_zset_pfx_scores (key, val) values ('w_zset_a','{b,c,d}');
+select key, cardinality(val), cardinality(scores) from db15_w_zset_pfx_scores order by key;
+   key    | cardinality | cardinality 
+----------+-------------+-------------
+ w_zset_a |           3 |           3
+(1 row)
+
+delete from db15_w_zset_pfx_scores;
+drop foreign table db15_w_zset_pfx_scores;
 -- non-singleton zset table keyset
 create foreign table db15_w_zset_kset(key text, val text[])
        server localredis

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -291,6 +291,39 @@ select * from db15_zset_keyset_array where key = 'zset1';
  zset1 | {z1,z2,z3,z4,z5,z6}
 (1 row)
 
+-- zset with a parallel scores array column
+create foreign table db15_zset_prefix_array_scores(key text, value text[], scores numeric[])
+       server localredis
+       options (tabletype 'zset', tablekeyprefix 'zset', database '15');
+create foreign table db15_zset_keyset_array_scores(key text, value text[], scores numeric[])
+       server localredis
+       options (tabletype 'zset', tablekeyset 'zkeys', database '15');
+select * from db15_zset_prefix_array_scores order by key;
+  key  |         value          |    scores     
+-------+------------------------+---------------
+ zset1 | {z1,z2,z3,z4,z5,z6}    | {1,2,3,4,5,6}
+ zset2 | {z7,z8,z9,z10,z11,z12} | {1,2,3,4,5,6}
+(2 rows)
+
+select * from db15_zset_prefix_array_scores where key = 'zset1';
+  key  |        value        |    scores     
+-------+---------------------+---------------
+ zset1 | {z1,z2,z3,z4,z5,z6} | {1,2,3,4,5,6}
+(1 row)
+
+select * from db15_zset_keyset_array_scores order by key;
+  key  |         value          |    scores     
+-------+------------------------+---------------
+ zset1 | {z1,z2,z3,z4,z5,z6}    | {1,2,3,4,5,6}
+ zset2 | {z7,z8,z9,z10,z11,z12} | {1,2,3,4,5,6}
+(2 rows)
+
+select * from db15_zset_keyset_array_scores where key = 'zset1';
+  key  |        value        |    scores     
+-------+---------------------+---------------
+ zset1 | {z1,z2,z3,z4,z5,z6} | {1,2,3,4,5,6}
+(1 row)
+
 -- singleton scalar
 create foreign table db15_1key(value text)
        server localredis
@@ -2122,3 +2155,59 @@ drop foreign table db15_bytea_set_dup;
 \! redis-cli < test/sql/redis_clean
 OK
 OK
+-- bytea[] members with a scores column: binary members must survive intact and
+-- keep their scores. Neither PR could express this shape on its own.
+-- -x reads the member from stdin, which is the only way to get real binary
+-- through redis-cli: an escape passed via argv arrives as literal characters.
+\! printf 'bin\001a' | redis-cli -n 15 -x zadd bsc_z 1 > /dev/null
+\! printf 'bin\002b' | redis-cli -n 15 -x zadd bsc_z 2 > /dev/null
+create foreign table db15_bsc(key text, value bytea[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bsc_');
+select key, scores from db15_bsc;
+  key  | scores 
+-------+--------
+ bsc_z | {1,2}
+(1 row)
+
+select octet_length(value[1]) as len1, octet_length(value[2]) as len2 from db15_bsc;
+ len1 | len2 
+------+------
+    5 |    5
+(1 row)
+
+drop foreign table db15_bsc;
+-- a scores column beside a scalar text members column: legal, because the
+-- scores column requires only zset, non-singleton and three columns
+create foreign table db15_ssc(key text, value text, scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bsc_');
+select * from db15_ssc;
+  key  |          value          | scores 
+-------+-------------------------+--------
+ bsc_z | {"bin\x01a","bin\x02b"} | {1,2}
+(1 row)
+
+drop foreign table db15_ssc;
+-- infinite scores round-trip both ways. numeric has accepted inf since PG 14,
+-- and Redis accepts PostgreSQL's Infinity rendering back again.
+\! redis-cli -n 15 zadd inf_z inf a -inf b 2.5 c > /dev/null
+create foreign table db15_inf(key text, value text[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'inf_');
+select * from db15_inf;
+  key  |  value  |          scores          
+-------+---------+--------------------------
+ inf_z | {b,c,a} | {-Infinity,2.5,Infinity}
+(1 row)
+
+insert into db15_inf values ('inf_z2', '{x,y}', '{inf,-inf}');
+select * from db15_inf order by key;
+  key   |  value  |          scores          
+--------+---------+--------------------------
+ inf_z  | {b,c,a} | {-Infinity,2.5,Infinity}
+ inf_z2 | {y,x}   | {-Infinity,Infinity}
+(2 rows)
+
+delete from db15_inf;
+drop foreign table db15_inf;

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1214,18 +1214,23 @@ select * from db15_w_zset_pfx;
 -----+-----
 (0 rows)
 
--- non-singleton zset table with a 3rd scores column: insert names only
--- the key and value columns, leaving scores to be populated by Redis
+-- a three-column zset table requires the scores column on INSERT, and a
+-- tablekeyprefix does not change that
 create foreign table db15_w_zset_pfx_scores(key text, val text[], scores numeric[])
        server localredis
        options (database '15', tabletype 'zset', tablekeyprefix 'w_zset_');
-insert into db15_w_zset_pfx_scores (key, val) values ('w_zset_a','{b,c,d}');
-select key, cardinality(val), cardinality(scores) from db15_w_zset_pfx_scores order by key;
-   key    | cardinality | cardinality 
-----------+-------------+-------------
- w_zset_a |           3 |           3
+insert into db15_w_zset_pfx_scores (key, val, scores) values ('w_zset_a','{b,c,d}','{1,2,3}');
+select key, val, scores from db15_w_zset_pfx_scores order by key;
+   key    |   val   | scores  
+----------+---------+---------
+ w_zset_a | {b,c,d} | {1,2,3}
 (1 row)
 
+-- the "set both together" error names this table's own columns, not the
+-- generic "members"/"scores"
+update db15_w_zset_pfx_scores set val = '{b,c,e}' where key = 'w_zset_a';
+ERROR:  updating "val" or "scores" requires setting both
+HINT:  A zset table's members and scores columns are written as a pair.
 delete from db15_w_zset_pfx_scores;
 drop foreign table db15_w_zset_pfx_scores;
 -- non-singleton zset table keyset
@@ -1851,6 +1856,161 @@ drop foreign table db15_bcol_list_arr;
 drop foreign table db15_bcol_sing_set;
 drop foreign table db15_bcol_sing_list;
 drop foreign table db15_bcol_scalar;
+-- Writable zset scores. The write path used to ignore the scores column and
+-- store the array index as the score, so an INSERT silently discarded the
+-- supplied scores and an UPDATE of the scores column wrote the score values
+-- as members.
+create foreign table db15_zs3(key text, members text[], scores text[])
+       server localredis
+       options (database '15', tabletype 'zset');
+-- INSERT must store the supplied scores, not 0,1,2
+insert into db15_zs3 values ('zs3', '{a,b,c}', '{10,20,30}');
+select * from db15_zs3 where key = 'zs3';
+ key | members |   scores   
+-----+---------+------------
+ zs3 | {a,b,c} | {10,20,30}
+(1 row)
+
+-- UPDATE setting both arrays rewrites members and scores together
+update db15_zs3 set members = '{a,b,d}', scores = '{11,21,41}' where key = 'zs3';
+select * from db15_zs3 where key = 'zs3';
+ key | members |   scores   
+-----+---------+------------
+ zs3 | {a,b,d} | {11,21,41}
+(1 row)
+
+-- a rename touches neither array and stays legal
+update db15_zs3 set key = 'zs3renamed' where key = 'zs3';
+select * from db15_zs3 where key = 'zs3renamed';
+    key     | members |   scores   
+------------+---------+------------
+ zs3renamed | {a,b,d} | {11,21,41}
+(1 row)
+
+-- setting only one of the pair is rejected
+update db15_zs3 set members = '{x,y,z}' where key = 'zs3renamed';
+ERROR:  updating "members" or "scores" requires setting both
+HINT:  A zset table's members and scores columns are written as a pair.
+update db15_zs3 set scores = '{1,2,3}' where key = 'zs3renamed';
+ERROR:  updating "members" or "scores" requires setting both
+HINT:  A zset table's members and scores columns are written as a pair.
+-- and the rejected updates must leave the key untouched, since the update
+-- path only replaces the key once the new contents are known to be valid
+select * from db15_zs3 where key = 'zs3renamed';
+    key     | members |   scores   
+------------+---------+------------
+ zs3renamed | {a,b,d} | {11,21,41}
+(1 row)
+
+-- mismatched array lengths are rejected, on UPDATE and on INSERT
+update db15_zs3 set members = '{a,b}', scores = '{1,2,3}' where key = 'zs3renamed';
+ERROR:  members and scores arrays must have the same length
+DETAIL:  members has 2 elements, scores has 3
+select * from db15_zs3 where key = 'zs3renamed';
+    key     | members |   scores   
+------------+---------+------------
+ zs3renamed | {a,b,d} | {11,21,41}
+(1 row)
+
+-- an invalid score is rejected by Redis itself, not by anything client
+-- side, so it is caught deep inside the rebuild; it must still leave the
+-- key exactly as it was rather than destroying part of the row
+update db15_zs3 set members = '{a,b,d}', scores = '{1,abc,3}' where key = 'zs3renamed';
+ERROR:  could not add zset members: ERR value is not a valid float
+select * from db15_zs3 where key = 'zs3renamed';
+    key     | members |   scores   
+------------+---------+------------
+ zs3renamed | {a,b,d} | {11,21,41}
+(1 row)
+
+-- NaN is likewise rejected by Redis, and likewise must not touch the row
+update db15_zs3 set members = '{a,b,d}', scores = '{1,NaN,3}' where key = 'zs3renamed';
+ERROR:  could not add zset members: ERR value is not a valid float
+select * from db15_zs3 where key = 'zs3renamed';
+    key     | members |   scores   
+------------+---------+------------
+ zs3renamed | {a,b,d} | {11,21,41}
+(1 row)
+
+insert into db15_zs3 values ('zs3bad', '{a,b,c}', '{1,2}');
+ERROR:  members and scores arrays must have the same length
+DETAIL:  members has 3 elements, scores has 2
+-- infinite scores round-trip; Redis accepts the spelling PostgreSQL emits
+insert into db15_zs3 values ('zs3inf', '{lo,mid,hi}', '{-Infinity,5,Infinity}');
+select * from db15_zs3 where key = 'zs3inf';
+  key   |   members   |    scores    
+--------+-------------+--------------
+ zs3inf | {lo,mid,hi} | {-inf,5,inf}
+(1 row)
+
+-- an INSERT that omits the scores column is rejected rather than falling
+-- back to positional scores
+insert into db15_zs3 (key, members) values ('zs3partial', '{a,b}');
+ERROR:  cannot insert NULL into a Redis table
+HINT:  A zset table's members and scores columns are written as a pair.
+-- a scores column that isn't an array is rejected outright, not
+-- reinterpreted as an array datum
+create foreign table db15_zsbad(key text, members text[], scores text)
+       server localredis
+       options (database '15', tabletype 'zset');
+insert into db15_zsbad values ('zsbadkey', '{a,b,c}', '{1,2,3}');
+ERROR:  scores column must be an array
+drop foreign table db15_zsbad;
+-- a numeric[] scores column exercises a non-text output function on
+-- UPDATE, not just INSERT; renaming the key in the same statement that
+-- sets both arrays shifts scores_pidx from 2 to 3
+create foreign table db15_zsnum(key text, members text[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset');
+insert into db15_zsnum values ('zsnum', '{a,b,c}', '{1,2,3}');
+update db15_zsnum set key = 'zsnumrenamed', members = '{a,b,d}', scores = '{4,5,6}' where key = 'zsnum';
+select * from db15_zsnum where key = 'zsnumrenamed';
+     key      | members | scores  
+--------------+---------+---------
+ zsnumrenamed | {a,b,d} | {4,5,6}
+(1 row)
+
+drop foreign table db15_zsnum;
+-- a two-column non-singleton zset is unaffected: members-only UPDATE is
+-- still allowed and scores are still positional
+create foreign table db15_zs2(key text, members text[])
+       server localredis
+       options (database '15', tabletype 'zset');
+insert into db15_zs2 values ('zs2', '{p,q,r}');
+update db15_zs2 set members = '{p,q,s}' where key = 'zs2';
+select * from db15_zs2 where key = 'zs2';
+ key | members 
+-----+---------
+ zs2 | {p,q,s}
+(1 row)
+
+\! redis-cli -n 15 zrange zs2 0 -1 withscores
+p
+0
+q
+1
+s
+2
+-- and a singleton zset is unaffected: its score column stays writable on
+-- its own
+\! redis-cli -n 15 zadd zs1 10 a 20 b > /dev/null
+create foreign table db15_szs(value text, score numeric)
+       server localredis
+       options (database '15', tabletype 'zset', singleton_key 'zs1');
+insert into db15_szs values ('c', 99);
+update db15_szs set score = 55 where value = 'a';
+update db15_szs set value = 'bb' where value = 'b';
+select * from db15_szs order by score;
+ value | score 
+-------+-------
+ bb    |    20
+ a     |    55
+ c     |    99
+(3 rows)
+
+drop foreign table db15_zs3;
+drop foreign table db15_zs2;
+drop foreign table db15_szs;
 -- all done, so now blow everything in the db away again
 \! redis-cli < test/sql/redis_clean
 OK

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -767,6 +767,21 @@ delete from db15_w_zset_pfx;
 
 select * from db15_w_zset_pfx;
 
+-- non-singleton zset table with a 3rd scores column: insert names only
+-- the key and value columns, leaving scores to be populated by Redis
+
+create foreign table db15_w_zset_pfx_scores(key text, val text[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'w_zset_');
+
+insert into db15_w_zset_pfx_scores (key, val) values ('w_zset_a','{b,c,d}');
+
+select key, cardinality(val), cardinality(scores) from db15_w_zset_pfx_scores order by key;
+
+delete from db15_w_zset_pfx_scores;
+
+drop foreign table db15_w_zset_pfx_scores;
+
 -- non-singleton zset table keyset
 
 create foreign table db15_w_zset_kset(key text, val text[])

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -767,16 +767,20 @@ delete from db15_w_zset_pfx;
 
 select * from db15_w_zset_pfx;
 
--- non-singleton zset table with a 3rd scores column: insert names only
--- the key and value columns, leaving scores to be populated by Redis
+-- a three-column zset table requires the scores column on INSERT, and a
+-- tablekeyprefix does not change that
 
 create foreign table db15_w_zset_pfx_scores(key text, val text[], scores numeric[])
        server localredis
        options (database '15', tabletype 'zset', tablekeyprefix 'w_zset_');
 
-insert into db15_w_zset_pfx_scores (key, val) values ('w_zset_a','{b,c,d}');
+insert into db15_w_zset_pfx_scores (key, val, scores) values ('w_zset_a','{b,c,d}','{1,2,3}');
 
-select key, cardinality(val), cardinality(scores) from db15_w_zset_pfx_scores order by key;
+select key, val, scores from db15_w_zset_pfx_scores order by key;
+
+-- the "set both together" error names this table's own columns, not the
+-- generic "members"/"scores"
+update db15_w_zset_pfx_scores set val = '{b,c,e}' where key = 'w_zset_a';
 
 delete from db15_w_zset_pfx_scores;
 
@@ -1275,6 +1279,125 @@ drop foreign table db15_bcol_list_arr;
 drop foreign table db15_bcol_sing_set;
 drop foreign table db15_bcol_sing_list;
 drop foreign table db15_bcol_scalar;
+-- Writable zset scores. The write path used to ignore the scores column and
+-- store the array index as the score, so an INSERT silently discarded the
+-- supplied scores and an UPDATE of the scores column wrote the score values
+-- as members.
+
+create foreign table db15_zs3(key text, members text[], scores text[])
+       server localredis
+       options (database '15', tabletype 'zset');
+
+-- INSERT must store the supplied scores, not 0,1,2
+insert into db15_zs3 values ('zs3', '{a,b,c}', '{10,20,30}');
+
+select * from db15_zs3 where key = 'zs3';
+
+-- UPDATE setting both arrays rewrites members and scores together
+update db15_zs3 set members = '{a,b,d}', scores = '{11,21,41}' where key = 'zs3';
+
+select * from db15_zs3 where key = 'zs3';
+
+-- a rename touches neither array and stays legal
+update db15_zs3 set key = 'zs3renamed' where key = 'zs3';
+
+select * from db15_zs3 where key = 'zs3renamed';
+
+-- setting only one of the pair is rejected
+update db15_zs3 set members = '{x,y,z}' where key = 'zs3renamed';
+
+update db15_zs3 set scores = '{1,2,3}' where key = 'zs3renamed';
+
+-- and the rejected updates must leave the key untouched, since the update
+-- path only replaces the key once the new contents are known to be valid
+select * from db15_zs3 where key = 'zs3renamed';
+
+-- mismatched array lengths are rejected, on UPDATE and on INSERT
+update db15_zs3 set members = '{a,b}', scores = '{1,2,3}' where key = 'zs3renamed';
+
+select * from db15_zs3 where key = 'zs3renamed';
+
+-- an invalid score is rejected by Redis itself, not by anything client
+-- side, so it is caught deep inside the rebuild; it must still leave the
+-- key exactly as it was rather than destroying part of the row
+update db15_zs3 set members = '{a,b,d}', scores = '{1,abc,3}' where key = 'zs3renamed';
+
+select * from db15_zs3 where key = 'zs3renamed';
+
+-- NaN is likewise rejected by Redis, and likewise must not touch the row
+update db15_zs3 set members = '{a,b,d}', scores = '{1,NaN,3}' where key = 'zs3renamed';
+
+select * from db15_zs3 where key = 'zs3renamed';
+
+insert into db15_zs3 values ('zs3bad', '{a,b,c}', '{1,2}');
+
+-- infinite scores round-trip; Redis accepts the spelling PostgreSQL emits
+insert into db15_zs3 values ('zs3inf', '{lo,mid,hi}', '{-Infinity,5,Infinity}');
+
+select * from db15_zs3 where key = 'zs3inf';
+
+-- an INSERT that omits the scores column is rejected rather than falling
+-- back to positional scores
+insert into db15_zs3 (key, members) values ('zs3partial', '{a,b}');
+
+-- a scores column that isn't an array is rejected outright, not
+-- reinterpreted as an array datum
+create foreign table db15_zsbad(key text, members text[], scores text)
+       server localredis
+       options (database '15', tabletype 'zset');
+
+insert into db15_zsbad values ('zsbadkey', '{a,b,c}', '{1,2,3}');
+
+drop foreign table db15_zsbad;
+
+-- a numeric[] scores column exercises a non-text output function on
+-- UPDATE, not just INSERT; renaming the key in the same statement that
+-- sets both arrays shifts scores_pidx from 2 to 3
+create foreign table db15_zsnum(key text, members text[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset');
+
+insert into db15_zsnum values ('zsnum', '{a,b,c}', '{1,2,3}');
+
+update db15_zsnum set key = 'zsnumrenamed', members = '{a,b,d}', scores = '{4,5,6}' where key = 'zsnum';
+
+select * from db15_zsnum where key = 'zsnumrenamed';
+
+drop foreign table db15_zsnum;
+
+-- a two-column non-singleton zset is unaffected: members-only UPDATE is
+-- still allowed and scores are still positional
+create foreign table db15_zs2(key text, members text[])
+       server localredis
+       options (database '15', tabletype 'zset');
+
+insert into db15_zs2 values ('zs2', '{p,q,r}');
+
+update db15_zs2 set members = '{p,q,s}' where key = 'zs2';
+
+select * from db15_zs2 where key = 'zs2';
+
+\! redis-cli -n 15 zrange zs2 0 -1 withscores
+
+-- and a singleton zset is unaffected: its score column stays writable on
+-- its own
+\! redis-cli -n 15 zadd zs1 10 a 20 b > /dev/null
+
+create foreign table db15_szs(value text, score numeric)
+       server localredis
+       options (database '15', tabletype 'zset', singleton_key 'zs1');
+
+insert into db15_szs values ('c', 99);
+
+update db15_szs set score = 55 where value = 'a';
+
+update db15_szs set value = 'bb' where value = 'b';
+
+select * from db15_szs order by score;
+
+drop foreign table db15_zs3;
+drop foreign table db15_zs2;
+drop foreign table db15_szs;
 
 -- all done, so now blow everything in the db away again
 

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -174,6 +174,22 @@ select * from db15_zset_prefix_array where key = 'zset1';
 select * from db15_zset_keyset_array order by key;
 select * from db15_zset_keyset_array where key = 'zset1';
 
+-- zset with a parallel scores array column
+
+create foreign table db15_zset_prefix_array_scores(key text, value text[], scores numeric[])
+       server localredis
+       options (tabletype 'zset', tablekeyprefix 'zset', database '15');
+
+create foreign table db15_zset_keyset_array_scores(key text, value text[], scores numeric[])
+       server localredis
+       options (tabletype 'zset', tablekeyset 'zkeys', database '15');
+
+select * from db15_zset_prefix_array_scores order by key;
+select * from db15_zset_prefix_array_scores where key = 'zset1';
+
+select * from db15_zset_keyset_array_scores order by key;
+select * from db15_zset_keyset_array_scores where key = 'zset1';
+
 -- singleton scalar
 
 create foreign table db15_1key(value text)
@@ -1468,3 +1484,50 @@ drop foreign table db15_bytea_set_dup;
 -- clean up bytea tests
 \! redis-cli < test/sql/redis_clean
 
+-- bytea[] members with a scores column: binary members must survive intact and
+-- keep their scores. Neither PR could express this shape on its own.
+
+-- -x reads the member from stdin, which is the only way to get real binary
+-- through redis-cli: an escape passed via argv arrives as literal characters.
+\! printf 'bin\001a' | redis-cli -n 15 -x zadd bsc_z 1 > /dev/null
+\! printf 'bin\002b' | redis-cli -n 15 -x zadd bsc_z 2 > /dev/null
+
+create foreign table db15_bsc(key text, value bytea[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bsc_');
+
+select key, scores from db15_bsc;
+
+select octet_length(value[1]) as len1, octet_length(value[2]) as len2 from db15_bsc;
+
+drop foreign table db15_bsc;
+
+-- a scores column beside a scalar text members column: legal, because the
+-- scores column requires only zset, non-singleton and three columns
+
+create foreign table db15_ssc(key text, value text, scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'bsc_');
+
+select * from db15_ssc;
+
+drop foreign table db15_ssc;
+
+-- infinite scores round-trip both ways. numeric has accepted inf since PG 14,
+-- and Redis accepts PostgreSQL's Infinity rendering back again.
+
+\! redis-cli -n 15 zadd inf_z inf a -inf b 2.5 c > /dev/null
+
+create foreign table db15_inf(key text, value text[], scores numeric[])
+       server localredis
+       options (database '15', tabletype 'zset', tablekeyprefix 'inf_');
+
+select * from db15_inf;
+
+insert into db15_inf values ('inf_z2', '{x,y}', '{inf,-inf}');
+
+select * from db15_inf order by key;
+
+delete from db15_inf;
+
+drop foreign table db15_inf;


### PR DESCRIPTION
## Summary
- Non-singleton zset tables can now optionally declare a third column, of type `numeric[]`, to receive each member's score alongside the existing key/members-array columns: `(key text, value text[], scores numeric[])`. `scores[i]` is the score of `value[i]`. Tables using the existing 2-column form are completely unaffected.
- Fetches `ZRANGE ... WITHSCORES` instead of plain `ZRANGE` when a 3-column zset table is detected, and splits the resulting flat `[member,score,member,score,...]` reply into two parallel array literal strings via a new `redis_zset_array_to_text()` helper (factored to share element-quoting logic with the existing `redis_array_to_text()`).
- This column is read-only for now; `INSERT`/`UPDATE` still require exactly the key/value columns, matching the existing non-singleton column-count validation.
- Based on the idea proposed in #30, redesigned here: that patch's approach (adding `WITHSCORES` without any change to consume the resulting interleaved array, plus an unrelated and apparently unintended recursive self-call) didn't actually work.

For context on why this design (a parallel array column) rather than something else: singleton zset tables already support scores naturally, since each row is one member and there's a free second column for its score. Non-singleton zset tables are one row per Redis key with the value column holding an array of *all* members for that key, so there's no existing per-row slot for a score — hence the parallel `scores[]` array, indexed the same as `value[]`.

## Dependency
This targets `redis-string-optimize` (#50), which targets `redis-command-refactor` (#49), which targets `concache` (#48). Should be merged after that stack, in order.

## Validation
- Full regression suite passes, with new tests for the 3-column form (both `tablekeyprefix` and `tablekeyset` variants, single-key and multi-key).
- Manually verified members and scores stay correctly paired/ordered across multiple keys against a live Valkey instance.

## Test plan
- [x] Full regression suite passes (including new tests)
- [x] 2-column (no scores) zset tables are unaffected
- [x] 3-column zset table returns correctly paired member/score arrays, single and multi-key