### PR TITLE
Validate declared column count for hash/list/set/zset tables

### DIFF
--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -1264,11 +1264,40 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 	 * foreign table's relation is already open (and locked) by the caller
 	 * in every context redisGetOptions is invoked from, so this just
 	 * borrows that lock.
+	 *
+	 * Dropped columns are excluded from the count: ALTER TABLE leaves the
+	 * attribute in the tuple descriptor, and counting it would reject a
+	 * table that is once again the right shape after a column was added and
+	 * dropped again.
+	 *
+	 * They can't simply be ignored, though. The scan fills values[] by
+	 * position - values[0] is the key, values[1] the data - and
+	 * BuildTupleFromCStrings indexes it by attribute number, skipping the
+	 * dropped ones. A dropped column ahead of a live one therefore pushes
+	 * that live column's index past the end of the array the scan
+	 * allocated, which is the same overrun this check exists to prevent. So
+	 * require the live columns to be the leading ones: trailing dropped
+	 * attributes are harmless, interleaved ones are not.
 	 */
 	{
 		Relation	rel = table_open(foreigntableid, NoLock);
-		int			natts = RelationGetDescr(rel)->natts;
+		TupleDesc	tupdesc = RelationGetDescr(rel);
+		int			natts = 0;		/* live columns only */
+		bool		seen_dropped = false;
+		bool		leading = true;
 		bool		valid;
+
+		for (int i = 0; i < tupdesc->natts; i++)
+		{
+			if (TupleDescAttr(tupdesc, i)->attisdropped)
+				seen_dropped = true;
+			else
+			{
+				natts++;
+				if (seen_dropped)
+					leading = false;
+			}
+		}
 
 		if (table_options->table_type == PG_REDIS_ZSET_TABLE)
 			valid = table_options->singleton_key ?
@@ -1284,6 +1313,11 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("table has incorrect number of columns")));
+
+		if (!leading)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("table has a dropped column among the columns this table type uses")));
 	}
 }
 

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -1257,6 +1257,34 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 
 	if (!table_options->database)
 		table_options->database = 0;
+
+	/*
+	 * Validate the declared column count against what this table type's
+	 * scan/modify code expects, before it's used to size any array. The
+	 * foreign table's relation is already open (and locked) by the caller
+	 * in every context redisGetOptions is invoked from, so this just
+	 * borrows that lock.
+	 */
+	{
+		Relation	rel = table_open(foreigntableid, NoLock);
+		int			natts = RelationGetDescr(rel)->natts;
+		bool		valid;
+
+		if (table_options->table_type == PG_REDIS_ZSET_TABLE)
+			valid = table_options->singleton_key ?
+				(natts == 1 || natts == 2) : (natts == 2 || natts == 3);
+		else if (table_options->table_type == PG_REDIS_HASH_TABLE)
+			valid = (natts == 2);
+		else	/* PG_REDIS_SCALAR_TABLE, PG_REDIS_SET_TABLE, PG_REDIS_LIST_TABLE */
+			valid = table_options->singleton_key ? (natts == 1) : (natts == 2);
+
+		table_close(rel, NoLock);
+
+		if (!valid)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("table has incorrect number of columns")));
+	}
 }
 
 /*

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1233,6 +1233,38 @@ ERROR:  updating "val" or "scores" requires setting both
 HINT:  A zset table's members and scores columns are written as a pair.
 delete from db15_w_zset_pfx_scores;
 drop foreign table db15_w_zset_pfx_scores;
+-- a table declared with the wrong number of columns for its type/shape is
+-- rejected on first use, for every table type this FDW supports
+create foreign table db15_set_bad_shape(key text, value text, extra text)
+       server localredis
+       options (tabletype 'set', tablekeyprefix 'set_bad_', database '15');
+select * from db15_set_bad_shape;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_set_bad_shape;
+create foreign table db15_list_bad_shape(key text, value text, extra text)
+       server localredis
+       options (tabletype 'list', tablekeyprefix 'list_bad_', database '15');
+select * from db15_list_bad_shape;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_list_bad_shape;
+create foreign table db15_hash_bad_shape(key text, value text, extra text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_bad_', database '15');
+select * from db15_hash_bad_shape;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_hash_bad_shape;
+create foreign table db15_zset_bad_shape(key text, value text, extra text, extra2 text)
+       server localredis
+       options (tabletype 'zset', tablekeyprefix 'zset_bad_', database '15');
+select * from db15_zset_bad_shape;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_zset_bad_shape;
+create foreign table db15_singleton_scalar_bad_shape(a text, b text)
+       server localredis
+       options (singleton_key 'bad_singleton', database '15');
+select * from db15_singleton_scalar_bad_shape;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_singleton_scalar_bad_shape;
 -- non-singleton zset table keyset
 create foreign table db15_w_zset_kset(key text, val text[])
        server localredis

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -1265,6 +1265,37 @@ create foreign table db15_singleton_scalar_bad_shape(a text, b text)
 select * from db15_singleton_scalar_bad_shape;
 ERROR:  table has incorrect number of columns
 drop foreign table db15_singleton_scalar_bad_shape;
+-- a dropped column must not count toward the declared column count: adding a
+-- column and dropping it again leaves the table as valid as it started
+create foreign table db15_hash_dropped(key text, value text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_drop_', database '15');
+alter foreign table db15_hash_dropped add column extra text;
+alter foreign table db15_hash_dropped drop column extra;
+select * from db15_hash_dropped;
+ key | value 
+-----+-------
+(0 rows)
+
+drop foreign table db15_hash_dropped;
+-- but dropping a column the table type does need is an error, not a table that
+-- silently reports NULL for the column that went missing
+create foreign table db15_hash_lost_value(key text, value text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_lost_', database '15');
+alter foreign table db15_hash_lost_value drop column value;
+select * from db15_hash_lost_value;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_hash_lost_value;
+-- a dropped column ahead of a live one leaves that live column at a position
+-- past the end of the values array the scan builds, so it is rejected as well
+create foreign table db15_hash_middrop(key text, mid text, value text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_mid_', database '15');
+alter foreign table db15_hash_middrop drop column mid;
+select * from db15_hash_middrop;
+ERROR:  table has a dropped column among the columns this table type uses
+drop foreign table db15_hash_middrop;
 -- non-singleton zset table keyset
 create foreign table db15_w_zset_kset(key text, val text[])
        server localredis

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -829,6 +829,46 @@ select * from db15_singleton_scalar_bad_shape;
 
 drop foreign table db15_singleton_scalar_bad_shape;
 
+-- a dropped column must not count toward the declared column count: adding a
+-- column and dropping it again leaves the table as valid as it started
+
+create foreign table db15_hash_dropped(key text, value text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_drop_', database '15');
+
+alter foreign table db15_hash_dropped add column extra text;
+alter foreign table db15_hash_dropped drop column extra;
+
+select * from db15_hash_dropped;
+
+drop foreign table db15_hash_dropped;
+
+-- but dropping a column the table type does need is an error, not a table that
+-- silently reports NULL for the column that went missing
+
+create foreign table db15_hash_lost_value(key text, value text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_lost_', database '15');
+
+alter foreign table db15_hash_lost_value drop column value;
+
+select * from db15_hash_lost_value;
+
+drop foreign table db15_hash_lost_value;
+
+-- a dropped column ahead of a live one leaves that live column at a position
+-- past the end of the values array the scan builds, so it is rejected as well
+
+create foreign table db15_hash_middrop(key text, mid text, value text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_mid_', database '15');
+
+alter foreign table db15_hash_middrop drop column mid;
+
+select * from db15_hash_middrop;
+
+drop foreign table db15_hash_middrop;
+
 -- non-singleton zset table keyset
 
 create foreign table db15_w_zset_kset(key text, val text[])

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -786,6 +786,49 @@ delete from db15_w_zset_pfx_scores;
 
 drop foreign table db15_w_zset_pfx_scores;
 
+-- a table declared with the wrong number of columns for its type/shape is
+-- rejected on first use, for every table type this FDW supports
+
+create foreign table db15_set_bad_shape(key text, value text, extra text)
+       server localredis
+       options (tabletype 'set', tablekeyprefix 'set_bad_', database '15');
+
+select * from db15_set_bad_shape;
+
+drop foreign table db15_set_bad_shape;
+
+create foreign table db15_list_bad_shape(key text, value text, extra text)
+       server localredis
+       options (tabletype 'list', tablekeyprefix 'list_bad_', database '15');
+
+select * from db15_list_bad_shape;
+
+drop foreign table db15_list_bad_shape;
+
+create foreign table db15_hash_bad_shape(key text, value text, extra text)
+       server localredis
+       options (tabletype 'hash', tablekeyprefix 'hash_bad_', database '15');
+
+select * from db15_hash_bad_shape;
+
+drop foreign table db15_hash_bad_shape;
+
+create foreign table db15_zset_bad_shape(key text, value text, extra text, extra2 text)
+       server localredis
+       options (tabletype 'zset', tablekeyprefix 'zset_bad_', database '15');
+
+select * from db15_zset_bad_shape;
+
+drop foreign table db15_zset_bad_shape;
+
+create foreign table db15_singleton_scalar_bad_shape(a text, b text)
+       server localredis
+       options (singleton_key 'bad_singleton', database '15');
+
+select * from db15_singleton_scalar_bad_shape;
+
+drop foreign table db15_singleton_scalar_bad_shape;
+
 -- non-singleton zset table keyset
 
 create foreign table db15_w_zset_kset(key text, val text[])


### PR DESCRIPTION
## Summary

- `redisIterateForeignScanMulti` and `redisIterateForeignScanSingleton` both build a fixed-size `values[]` array (2-3 slots depending on table type/shape) and hand it to `BuildTupleFromCStrings`, which iterates the foreign table's *actual* declared column count. Nothing validated that count against what the code allocates, so a table declared with more columns than its type/shape expects caused `BuildTupleFromCStrings` to read past the end of `values[]`, and the resulting garbage pointer got dereferenced as a C string by the corresponding type input function - a wild-pointer dereference reachable by any role with `CREATE FOREIGN TABLE` + `USAGE` on the server, no elevated privilege needed.
- Adds a column-count check to `redisGetOptions`, mirroring the pattern already used for geo tables' shape validation (#56), covering every scalar/hash/set/list/zset singleton and non-singleton shape this FDW supports, including the zset-with-scores 3-column case from #54 (hence this PR targeting `redis-zset-scores` rather than `master`).

Found while reviewing #48-#56; #56 already had the fix for geo tables specifically, this extends the same pattern to the remaining table types.

## Test plan

- [x] `make installcheck` passes against a real PostgreSQL 19beta1 + Redis instance
- [x] New regression cases confirm a table declared with the wrong column count for its type/shape (set, list, hash, zset, and a singleton scalar) is rejected with a clean error on first use, for both the multi-row and singleton scan paths
- [x] Existing test suite (all table shapes already in the regression file) continues to pass unchanged, confirming the validation doesn't reject any currently-supported shape