### PR TITLE
Copy Redis reply values by length, not pstrdup (fix binary over-read)

### DIFF
--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3314,8 +3314,15 @@ redisExecForeignUpdate(EState *estate,
 							check_reply(ereply, context,
 									  ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 										"getting score for key %s", keyval);
-							priority = pstrdup(ereply->str);
+							/*
+							 * Copy by length, not pstrdup: a Redis value is
+							 * binary and may contain NULs, which pstrdup would
+							 * truncate while priority_len kept the full length,
+							 * making ZADD read past the allocation.
+							 */
 							priority_len = ereply->len;
+							priority = palloc(priority_len);
+							memcpy(priority, ereply->str, priority_len);
 							freeReplyObject(ereply);
 						}
 						else
@@ -3351,8 +3358,15 @@ redisExecForeignUpdate(EState *estate,
 							check_reply(ereply, context,
 									  ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 										"fetching value for key %s", keyval);
-							nval = pstrdup(ereply->str);
+							/*
+							 * Copy by length, not pstrdup: a Redis hash value
+							 * is binary and may contain NULs, which pstrdup
+							 * would truncate while nval_len kept the full
+							 * length, making HSET read past the allocation.
+							 */
 							nval_len = ereply->len;
+							nval = palloc(nval_len);
+							memcpy(nval, ereply->str, nval_len);
 							freeReplyObject(ereply);
 						}
 						else

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -472,6 +472,19 @@ select * from db15_w_1key_hash order by key;
  x   | y
 (2 rows)
 
+-- a key-only UPDATE re-stores the existing value using its full Redis length,
+-- so a value containing an embedded NUL must survive byte-for-byte (copying it
+-- with pstrdup would truncate at the NUL while the length stayed full, reading
+-- past the buffer and corrupting the value).  Seed a binary value plus a
+-- pristine copy directly in Redis, rename the field via the FDW, then compare
+-- server-side.
+\! printf 'ab\000cdefghij' | redis-cli -n 15 -x hset w_1key_hash binkey
+1
+\! printf 'ab\000cdefghij' | redis-cli -n 15 -x hset w_1key_hash binkey_orig
+1
+update db15_w_1key_hash set key = 'binkey2' where key = 'binkey';
+\! redis-cli -n 15 eval "return (redis.call('HGET',KEYS[1],ARGV[1]) == redis.call('HGET',KEYS[1],ARGV[2])) and 'value preserved' or 'value CORRUPTED'" 1 w_1key_hash binkey2 binkey_orig
+value preserved
 -- singleton list
 create foreign table db15_w_1key_list(val text)
        server localredis

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -291,6 +291,17 @@ update db15_w_1key_hash set key = 'w' where key = 'e';
 
 select * from db15_w_1key_hash order by key;
 
+-- a key-only UPDATE re-stores the existing value using its full Redis length,
+-- so a value containing an embedded NUL must survive byte-for-byte (copying it
+-- with pstrdup would truncate at the NUL while the length stayed full, reading
+-- past the buffer and corrupting the value).  Seed a binary value plus a
+-- pristine copy directly in Redis, rename the field via the FDW, then compare
+-- server-side.
+\! printf 'ab\000cdefghij' | redis-cli -n 15 -x hset w_1key_hash binkey
+\! printf 'ab\000cdefghij' | redis-cli -n 15 -x hset w_1key_hash binkey_orig
+update db15_w_1key_hash set key = 'binkey2' where key = 'binkey';
+\! redis-cli -n 15 eval "return (redis.call('HGET',KEYS[1],ARGV[1]) == redis.call('HGET',KEYS[1],ARGV[2])) and 'value preserved' or 'value CORRUPTED'" 1 w_1key_hash binkey2 binkey_orig
+
 -- singleton list
 
 create foreign table db15_w_1key_list(val text)


### PR DESCRIPTION
## Fix: out-of-bounds heap read / corruption on binary hash (and zset) values

A singleton-key `UPDATE` that changes only the key re-stores the existing value/score fetched via `HGET`/`ZSCORE` using the reply's **full length**, but copied it with `pstrdup()`, which stops at the first NUL. A binary value containing a `\0` is truncated in the copy while the length stays full, so the following `HSET`/`ZADD` reads **past the allocation**.

**Confirmed against Valkey 8.1.4 + PG18** (this branch = #50 + fix):
```
HSET h k1 = ab\0cdefghij   (11 bytes)
UPDATE ... SET key=newk1 WHERE key=k1
-- before: ab\0 + 8 bytes of heap garbage
-- after : byte-identical (server-side compare returns EQUAL)
```
Fix copies with `palloc()`+`memcpy()` at the reply length (binary-safe; also removes the crash when the reply is NIL / `str==NULL`). Adds a regression test that seeds a NUL-containing value and compares server-side. Full suite green.

Targets #50 (`redis-string-optimize`); merge into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)