### PR TITLE
Reject NULL point/coordinates on geo INSERT (fix backend crash)

### DIFF
--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -2768,11 +2768,21 @@ redisExecForeignInsert(EState *estate,
 			(fmstate->table_type == PG_REDIS_GEO_TABLE && fmstate->geo_ewkt))
 		{
 			extra = slot_getattr(slot, 2, &isnull);	/* score / value / point */
+			if (isnull)
+				ereport(ERROR,
+						(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+						 errmsg("cannot insert a NULL value into a Redis foreign table")));
 		}
 		else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
 		{
-			extra = slot_getattr(slot, 2, &isnull);	/* lat */
-			extra2 = slot_getattr(slot, 3, &isnull);	/* long */
+			bool		isnull2;
+
+			extra = slot_getattr(slot, 2, &isnull);		/* lat */
+			extra2 = slot_getattr(slot, 3, &isnull2);	/* long */
+			if (isnull || isnull2)
+				ereport(ERROR,
+						(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+						 errmsg("cannot insert NULL coordinates into a Redis geo table")));
 		}
 
 		switch (fmstate->table_type)

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -707,6 +707,11 @@ from db15_w_1key_geo order by value;
  Catania2 | 42.0000 | 14.0000
 (1 row)
 
+-- NULL coordinates are rejected, not silently stored as 0 (and not a crash)
+insert into db15_w_1key_geo (value, lat, long) values ('NullLat', NULL, 5);
+ERROR:  cannot insert NULL coordinates into a Redis geo table
+insert into db15_w_1key_geo (value, lat, long) values ('NullLong', 5, NULL);
+ERROR:  cannot insert NULL coordinates into a Redis geo table
 delete from db15_w_1key_geo;
 -- geo tables require singleton_key
 create foreign table db15_geo_no_singleton(key text, lat double precision, long double precision)
@@ -760,6 +765,9 @@ ERROR:  unsupported SRID 3857 in geo point value: only 4326 is supported
 -- malformed point text is rejected
 insert into db15_w_1key_geo_ewkt (value, point) values ('Bad', 'not a point');
 ERROR:  invalid geo point value: "not a point"
+-- a NULL point is rejected (regression: previously a NULL-pointer crash)
+insert into db15_w_1key_geo_ewkt (value, point) values ('Null', NULL);
+ERROR:  cannot insert a NULL value into a Redis foreign table
 delete from db15_w_1key_geo_ewkt where value = 'Messina';
 -- update the whole point at once (partial-coordinate update, as with plain
 -- geo, isn't meaningful here since there's only one point column)

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -440,6 +440,10 @@ delete from db15_w_1key_geo where value = 'Palermo2';
 select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
 from db15_w_1key_geo order by value;
 
+-- NULL coordinates are rejected, not silently stored as 0 (and not a crash)
+insert into db15_w_1key_geo (value, lat, long) values ('NullLat', NULL, 5);
+insert into db15_w_1key_geo (value, lat, long) values ('NullLong', 5, NULL);
+
 delete from db15_w_1key_geo;
 
 -- geo tables require singleton_key
@@ -485,6 +489,9 @@ insert into db15_w_1key_geo_ewkt (value, point) values ('Rome', 'SRID=3857;POINT
 
 -- malformed point text is rejected
 insert into db15_w_1key_geo_ewkt (value, point) values ('Bad', 'not a point');
+
+-- a NULL point is rejected (regression: previously a NULL-pointer crash)
+insert into db15_w_1key_geo_ewkt (value, point) values ('Null', NULL);
 
 delete from db15_w_1key_geo_ewkt where value = 'Messina';
 


### PR DESCRIPTION
## Fix: NULL geo INSERT crashes the backend

`redisExecForeignInsert` fetched the geo value column(s) with `slot_getattr` but never checked `isnull`. A NULL EWKT point reached `TextDatumGetCString((Datum) 0)` → NULL-pointer dereference → **backend segfault**.

**Confirmed against Valkey 8.1.4 + PG18** (this branch = #56 + fix):
```
INSERT INTO geo_ewkt (value, point) VALUES ('x', NULL);
-- before: server closed the connection unexpectedly (SIGSEGV, recovery)
-- after : ERROR: cannot insert a NULL value into a Redis foreign table
```
Also fixes the lat/long shape silently storing a NULL coordinate as `0`. Adds regression tests for both shapes. Full suite green.

Targets #56 (`redis-geo-tabletype`); merge into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)