### PR TITLE
Add geo tabletype for singleton Redis geospatial indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Features
   - `INSERT` and `UPDATE` only work for singleton key `ZSET` tables if they have the
   priority column
   - non-singleton non-scalar tables must have an array type for the second column
+  - `GEO` tables are only supported with `singleton_key`
 
 ### Binary data (bytea) support
 
@@ -158,7 +159,7 @@ command:
 
 - **tabletype** as *string*, optional, no default
 
-  Can be `hash`, `list`, `set` or `zset`. If not provided only look at scalar values.
+  Can be `hash`, `list`, `set`, `zset` or `geo`. If not provided only look at scalar values.
 
 - **tablekeyprefix** as *string*, optional, no default
 
@@ -219,6 +220,85 @@ Singleton key tables are returned as rows with a single column of text
 in the case of lists sets and scalars, rows with key and value text columns
 for hashes, and rows with a value text columns and an optional numeric score
 column for zsets.
+
+### Geo tables
+
+`tabletype 'geo'` exposes a Redis [geospatial index](https://redis.io/docs/latest/develop/data-types/geospatial/)
+(a zset under the hood, with each member's score encoding its coordinates)
+as a table of `(member, lat, long)` rows. Only the singleton-key form is
+supported:
+
+```sql
+CREATE FOREIGN TABLE mygeo (value text, lat double precision, long double precision)
+    SERVER redis_server
+    OPTIONS (database '0', tabletype 'geo', singleton_key 'mygeo');
+
+INSERT INTO mygeo (value, lat, long) VALUES ('Palermo', 38.115556, 13.361389);
+
+SELECT * FROM mygeo;
+```
+
+`UPDATE` supports changing the member name, either coordinate, or both at
+once; updating only one coordinate looks up the other via `GEOPOS` so it's
+preserved. Note that Redis's internal geohash encoding is not perfectly
+exact (sub-meter precision loss), so a coordinate read back may differ
+very slightly from what was inserted.
+
+Non-singleton geo tables are not currently supported.
+
+#### Using geo tables with PostGIS
+
+`redis_fdw` itself has no PostGIS dependency — geo tables always expose
+plain `double precision` columns. If PostGIS is installed,
+a `geometry(Point, 4326)` view can be layered on top with an
+`INSTEAD OF` trigger, giving full read/write access via
+`ST_Distance`/`ST_DWithin`/etc. without redis_fdw needing to know
+PostGIS exists:
+
+```sql
+CREATE VIEW mygeo_postgis AS
+  SELECT value, ST_SetSRID(ST_MakePoint(long, lat), 4326) AS geom
+  FROM mygeo;
+
+CREATE FUNCTION mygeo_postgis_write() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM mygeo WHERE value = OLD.value;
+    RETURN OLD;
+  ELSIF TG_OP = 'UPDATE' THEN
+    UPDATE mygeo SET value = NEW.value, lat = ST_Y(NEW.geom), long = ST_X(NEW.geom)
+      WHERE value = OLD.value;
+    RETURN NEW;
+  ELSE -- INSERT
+    INSERT INTO mygeo (value, lat, long) VALUES (NEW.value, ST_Y(NEW.geom), ST_X(NEW.geom));
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+CREATE TRIGGER mygeo_postgis_write
+  INSTEAD OF INSERT OR UPDATE OR DELETE ON mygeo_postgis
+  FOR EACH ROW EXECUTE FUNCTION mygeo_postgis_write();
+```
+
+```sql
+INSERT INTO mygeo_postgis (value, geom) VALUES ('Rome', ST_SetSRID(ST_MakePoint(12.4964, 41.9028), 4326));
+
+-- distance in metres between two members, using a geography cast
+SELECT a.value, b.value,
+       ST_Distance(a.geom::geography, b.geom::geography) AS metres
+FROM mygeo_postgis a, mygeo_postgis b
+WHERE a.value = 'Rome' AND b.value = 'Palermo';
+
+UPDATE mygeo_postgis SET geom = ST_SetSRID(ST_MakePoint(12.5, 42.0), 4326) WHERE value = 'Rome';
+
+DELETE FROM mygeo_postgis WHERE value = 'Rome';
+```
+
+`4326` is WGS84 (plain latitude/longitude, the same coordinate system
+`GEOADD`/`GEOPOS` use), so no reprojection is needed going in either
+direction.
 
 ## IMPORT FOREIGN SCHEMA options
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ command:
 
 - **tabletype** as *string*, optional, no default
 
-  Can be `hash`, `list`, `set`, `zset` or `geo`. If not provided only look at scalar values.
+  Can be `hash`, `list`, `set`, `zset`, `geo` or `geo4326`. If not provided only look at scalar values.
 
 - **tablekeyprefix** as *string*, optional, no default
 
@@ -246,13 +246,54 @@ very slightly from what was inserted.
 
 Non-singleton geo tables are not currently supported.
 
+### Geo4326 tables
+
+`tabletype 'geo4326'` is a variant of `geo` that exposes the same
+underlying Redis geospatial index as a table of `(member, point)` rows,
+where `point` is EWKT text such as `SRID=4326;POINT(long lat)` —
+PostGIS's own text representation of a `geometry(Point, 4326)`. This
+makes it simpler to use with PostGIS: no view or trigger is needed,
+just cast the column directly.
+
+```sql
+CREATE FOREIGN TABLE mygeo (value text, point text)
+    SERVER redis_server
+    OPTIONS (database '0', tabletype 'geo4326', singleton_key 'mygeo');
+
+INSERT INTO mygeo (value, point) VALUES ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)');
+
+SELECT value, point::geometry FROM mygeo;
+
+-- distance in metres between two members, using a geography cast
+SELECT a.value, b.value,
+       ST_Distance(a.point::geometry::geography, b.point::geometry::geography) AS metres
+FROM mygeo a, mygeo b
+WHERE a.value = 'Palermo' AND b.value = 'Catania';
+```
+
+A bare WKT point (no `SRID=...;` prefix, e.g. `POINT(13.361389 38.115556)`)
+is also accepted on input, since 4326 is implied. Any other SRID is
+rejected, since `4326` is the only coordinate system that matches what
+`GEOADD`/`GEOPOS` use.
+
+`UPDATE` supports changing the member name, the point, or both at once,
+but — unlike plain `geo` — not just one coordinate: since there's a
+single `point` column instead of separate `lat`/`long` columns, setting
+it always replaces both coordinates together. Renaming a member without
+touching `point` still preserves its position via `GEOPOS`, just as with
+`geo`. The same geohash precision caveat as `geo` applies: a point read
+back may differ very slightly from what was inserted.
+
+Non-singleton geo4326 tables are not currently supported.
+
 #### Using geo tables with PostGIS
 
 `redis_fdw` itself has no PostGIS dependency — geo tables always expose
-plain `double precision` columns. If PostGIS is installed,
-a `geometry(Point, 4326)` view can be layered on top with an
-`INSTEAD OF` trigger, giving full read/write access via
-`ST_Distance`/`ST_DWithin`/etc. without redis_fdw needing to know
+plain `double precision` columns (or, for `geo4326`, plain EWKT text —
+see above for casting that directly to `geometry`). If PostGIS is
+installed, a `geometry(Point, 4326)` view can be layered on top of a
+`geo` table with an `INSTEAD OF` trigger, giving full read/write access
+via `ST_Distance`/`ST_DWithin`/etc. without redis_fdw needing to know
 PostGIS exists:
 
 ```sql

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ command:
 
 - **tabletype** as *string*, optional, no default
 
-  Can be `hash`, `list`, `set`, `zset`, `geo` or `geo4326`. If not provided only look at scalar values.
+  Can be `hash`, `list`, `set`, `zset` or `geo`. If not provided only look at scalar values.
 
 - **tablekeyprefix** as *string*, optional, no default
 
@@ -224,9 +224,19 @@ column for zsets.
 ### Geo tables
 
 `tabletype 'geo'` exposes a Redis [geospatial index](https://redis.io/docs/latest/develop/data-types/geospatial/)
-(a zset under the hood, with each member's score encoding its coordinates)
-as a table of `(member, lat, long)` rows. Only the singleton-key form is
-supported:
+(a zset under the hood, with each member's score encoding its coordinates).
+Only the singleton-key form is supported. The table can be declared in
+either of two shapes, and `redis_fdw` picks the matching behavior from the
+declared columns — there's no separate tabletype for this:
+
+- `(member text, lat double precision, long double precision)` — a row per
+  member with separate coordinate columns.
+- `(member text, point text)` — a row per member with a single EWKT point
+  column such as `SRID=4326;POINT(long lat)`, PostGIS's own text
+  representation of a `geometry(Point, 4326)`. This is simpler to use with
+  PostGIS: no view or trigger is needed, just cast the column directly.
+
+Any other column count or column types on a `geo` table raise an error.
 
 ```sql
 CREATE FOREIGN TABLE mygeo (value text, lat double precision, long double precision)
@@ -238,63 +248,47 @@ INSERT INTO mygeo (value, lat, long) VALUES ('Palermo', 38.115556, 13.361389);
 SELECT * FROM mygeo;
 ```
 
-`UPDATE` supports changing the member name, either coordinate, or both at
-once; updating only one coordinate looks up the other via `GEOPOS` so it's
-preserved. Note that Redis's internal geohash encoding is not perfectly
-exact (sub-meter precision loss), so a coordinate read back may differ
-very slightly from what was inserted.
-
-Non-singleton geo tables are not currently supported.
-
-### Geo4326 tables
-
-`tabletype 'geo4326'` is a variant of `geo` that exposes the same
-underlying Redis geospatial index as a table of `(member, point)` rows,
-where `point` is EWKT text such as `SRID=4326;POINT(long lat)` —
-PostGIS's own text representation of a `geometry(Point, 4326)`. This
-makes it simpler to use with PostGIS: no view or trigger is needed,
-just cast the column directly.
-
 ```sql
-CREATE FOREIGN TABLE mygeo (value text, point text)
+CREATE FOREIGN TABLE mygeo_ewkt (value text, point text)
     SERVER redis_server
-    OPTIONS (database '0', tabletype 'geo4326', singleton_key 'mygeo');
+    OPTIONS (database '0', tabletype 'geo', singleton_key 'mygeo_ewkt');
 
-INSERT INTO mygeo (value, point) VALUES ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)');
+INSERT INTO mygeo_ewkt (value, point) VALUES ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)');
 
-SELECT value, point::geometry FROM mygeo;
+SELECT value, point::geometry FROM mygeo_ewkt;
 
 -- distance in metres between two members, using a geography cast
 SELECT a.value, b.value,
        ST_Distance(a.point::geometry::geography, b.point::geometry::geography) AS metres
-FROM mygeo a, mygeo b
+FROM mygeo_ewkt a, mygeo_ewkt b
 WHERE a.value = 'Palermo' AND b.value = 'Catania';
 ```
 
 A bare WKT point (no `SRID=...;` prefix, e.g. `POINT(13.361389 38.115556)`)
-is also accepted on input, since 4326 is implied. Any other SRID is
-rejected, since `4326` is the only coordinate system that matches what
-`GEOADD`/`GEOPOS` use.
+is also accepted on input for the `point`-column shape, since 4326 is
+implied. Any other SRID is rejected, since `4326` is the only coordinate
+system that matches what `GEOADD`/`GEOPOS` use.
 
-`UPDATE` supports changing the member name, the point, or both at once,
-but — unlike plain `geo` — not just one coordinate: since there's a
-single `point` column instead of separate `lat`/`long` columns, setting
-it always replaces both coordinates together. Renaming a member without
-touching `point` still preserves its position via `GEOPOS`, just as with
-`geo`. The same geohash precision caveat as `geo` applies: a point read
-back may differ very slightly from what was inserted.
+`UPDATE` supports changing the member name, the coordinates, or both at
+once. With the `lat`/`long` shape, updating just one coordinate looks up
+the other via `GEOPOS` so it's preserved; with the `point` shape there's
+only one column to update, so setting it always replaces both coordinates
+together (renaming a member without touching `point` still preserves its
+position via `GEOPOS`). Note that Redis's internal geohash encoding is not
+perfectly exact (sub-meter precision loss), so a coordinate read back may
+differ very slightly from what was inserted.
 
-Non-singleton geo4326 tables are not currently supported.
+Non-singleton geo tables are not currently supported.
 
 #### Using geo tables with PostGIS
 
 `redis_fdw` itself has no PostGIS dependency — geo tables always expose
-plain `double precision` columns (or, for `geo4326`, plain EWKT text —
-see above for casting that directly to `geometry`). If PostGIS is
-installed, a `geometry(Point, 4326)` view can be layered on top of a
-`geo` table with an `INSTEAD OF` trigger, giving full read/write access
-via `ST_Distance`/`ST_DWithin`/etc. without redis_fdw needing to know
-PostGIS exists:
+plain `double precision` columns, or plain EWKT text for the `point`-column
+shape (see above for casting that directly to `geometry`). If PostGIS is
+installed, a `geometry(Point, 4326)` view can be layered on top of the
+`lat`/`long` shape with an `INSTEAD OF` trigger, giving full read/write
+access via `ST_Distance`/`ST_DWithin`/etc. without redis_fdw needing to
+know PostGIS exists:
 
 ```sql
 CREATE VIEW mygeo_postgis AS

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -26,6 +26,7 @@
 #error Selected Postgresql version is very old for this branch, try to use some older branch.
 #endif
 
+#include <ctype.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -125,7 +126,8 @@ typedef enum
 	PG_REDIS_LIST_TABLE,
 	PG_REDIS_SET_TABLE,
 	PG_REDIS_ZSET_TABLE,
-	PG_REDIS_GEO_TABLE
+	PG_REDIS_GEO_TABLE,
+	PG_REDIS_GEO4326_TABLE
 } redis_table_type;
 
 /*
@@ -410,6 +412,10 @@ static void redis_geo_fill_missing_coords(redisContext *context,
 						char *keyval,
 						char **lat, size_t *lat_len,
 						char **lon, size_t *lon_len);
+static char *redis_format_geo4326_point(const char *long_str, const char *lat_str);
+static void redis_parse_geo4326_point(const char *text,
+						char **lon, size_t *lon_len,
+						char **lat, size_t *lat_len);
 
 /* Connection cache functions */
 static void redis_conn_cache_init(void);
@@ -1124,11 +1130,13 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 				tabletype = PG_REDIS_ZSET_TABLE;
 			else if (strcmp(typeval, "geo") == 0)
 				tabletype = PG_REDIS_GEO_TABLE;
+			else if (strcmp(typeval, "geo4326") == 0)
+				tabletype = PG_REDIS_GEO4326_TABLE;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid tabletype (%s) - must be hash, "
-								"list, set, zset or geo", typeval)));
+								"list, set, zset, geo or geo4326", typeval)));
 		}
 	}
 
@@ -1251,11 +1259,13 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 				table_options->table_type = PG_REDIS_ZSET_TABLE;
 			else if (strcmp(typeval, "geo") == 0)
 				table_options->table_type = PG_REDIS_GEO_TABLE;
+			else if (strcmp(typeval, "geo4326") == 0)
+				table_options->table_type = PG_REDIS_GEO4326_TABLE;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid tabletype (%s) - must be hash, "
-								"list, set, zset or geo", typeval)));
+								"list, set, zset, geo or geo4326", typeval)));
 		}
 	}
 
@@ -1317,6 +1327,8 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 			valid = (natts == 2);
 		else if (table_options->table_type == PG_REDIS_GEO_TABLE)
 			valid = (natts == 3);	/* member, latitude, longitude */
+		else if (table_options->table_type == PG_REDIS_GEO4326_TABLE)
+			valid = (natts == 2);	/* member, EWKT point */
 		else	/* PG_REDIS_SCALAR_TABLE, PG_REDIS_SET_TABLE, PG_REDIS_LIST_TABLE */
 			valid = table_options->singleton_key ? (natts == 1) : (natts == 2);
 
@@ -1333,7 +1345,8 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 					 errmsg("table has a dropped column among the columns this table type uses")));
 	}
 
-	if (table_options->table_type == PG_REDIS_GEO_TABLE &&
+	if ((table_options->table_type == PG_REDIS_GEO_TABLE ||
+		 table_options->table_type == PG_REDIS_GEO4326_TABLE) &&
 		!table_options->singleton_key)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1443,6 +1456,7 @@ redisGetForeignRelSize(PlannerInfo *root,
 				break;
 			case PG_REDIS_ZSET_TABLE:
 			case PG_REDIS_GEO_TABLE:
+			case PG_REDIS_GEO4326_TABLE:
 				/* geo sets are zsets internally, so ZCARD works for them too */
 				reply = redisCommand(context, "ZCARD %s", table_options.singleton_key);
 				break;
@@ -1780,6 +1794,7 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 				reply = redisCommand(context, "ZRANGEBYSCORE %s -inf inf WITHSCORES", table_options.singleton_key);
 				break;
 			case PG_REDIS_GEO_TABLE:
+			case PG_REDIS_GEO4326_TABLE:
 				/*
 				 * There's no direct "get everything" command for geo sets,
 				 * so search a box large enough to cover the whole Earth
@@ -2377,8 +2392,9 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 				break;
 		}
 	}
-	else if (festate->table_type == PG_REDIS_GEO_TABLE &&
-			festate->row < festate->reply->elements)
+	else if ((festate->table_type == PG_REDIS_GEO_TABLE ||
+			  festate->table_type == PG_REDIS_GEO4326_TABLE) &&
+			 festate->row < festate->reply->elements)
 	{
 		/*
 		 * GEOSEARCH ... WITHCOORD replies with one entry per member:
@@ -2493,6 +2509,12 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 			values[2] = long_str;
 			tuple = BuildTupleFromCStrings(festate->attinmeta, values);
 			ExecStoreHeapTuple(tuple, slot, false);
+		}
+		else if (festate->table_type == PG_REDIS_GEO4326_TABLE)
+		{
+			values = (char **) palloc(sizeof(char *) * 2);
+			values[0] = key;
+			values[1] = redis_format_geo4326_point(long_str, lat_str);
 		}
 		else
 		{
@@ -3121,6 +3143,7 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 			{
 				case PG_REDIS_HASH_TABLE:
 				case PG_REDIS_ZSET_TABLE:
+				case PG_REDIS_GEO4326_TABLE:
 					expected_cols = 2;
 					break;
 				case PG_REDIS_GEO_TABLE:
@@ -3462,6 +3485,7 @@ redisExecForeignInsert(EState *estate,
 				break;
 			case PG_REDIS_ZSET_TABLE:
 			case PG_REDIS_GEO_TABLE:
+			case PG_REDIS_GEO4326_TABLE:
 				sreply = redis_command(context, "ZRANK",		/* n or nil */
 									   fmstate->singleton_key, fmstate->singleton_key_len,
 									   NULL, 0, key_data, key_len);
@@ -3480,7 +3504,8 @@ redisExecForeignInsert(EState *estate,
 						"failed checking key existence", NULL);
 
 			if (fmstate->table_type != PG_REDIS_ZSET_TABLE &&
-				fmstate->table_type != PG_REDIS_GEO_TABLE)
+				fmstate->table_type != PG_REDIS_GEO_TABLE &&
+				fmstate->table_type != PG_REDIS_GEO4326_TABLE)
 				ok = sreply->type == REDIS_REPLY_INTEGER &&
 					sreply->integer == 0;
 			else
@@ -3506,9 +3531,10 @@ redisExecForeignInsert(EState *estate,
 		/* get the second value for appropriate table types */
 
 		if (fmstate->table_type == PG_REDIS_ZSET_TABLE ||
-			fmstate->table_type == PG_REDIS_HASH_TABLE)
+			fmstate->table_type == PG_REDIS_HASH_TABLE ||
+			fmstate->table_type == PG_REDIS_GEO4326_TABLE)
 		{
-			extra = slot_getattr(slot, 2, &isnull);
+			extra = slot_getattr(slot, 2, &isnull);	/* score / value / point */
 			if (isnull)
 				ereport(ERROR,
 						(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
@@ -3584,6 +3610,36 @@ redisExecForeignInsert(EState *estate,
 					argvlen[1] = fmstate->singleton_key_len;
 					argv[2] = long_data;
 					argvlen[2] = long_len;
+					argv[3] = lat_data;
+					argvlen[3] = lat_len;
+					argv[4] = key_data;
+					argvlen[4] = key_len;
+					sreply = redisCommandArgv(context, 5, argv, argvlen);
+				}
+				break;
+			case PG_REDIS_GEO4326_TABLE:
+				{
+					char	   *point_text = fmstate->val_types[1] == REDIS_VAL_TEXT ?
+						TextDatumGetCString(extra) :
+						OutputFunctionCall(&fmstate->p_flinfo[1], extra);
+					char	   *lon_data,
+							   *lat_data;
+					size_t		lon_len,
+								lat_len;
+					const char *argv[5];
+					size_t		argvlen[5];
+
+					redis_parse_geo4326_point(point_text,
+											  &lon_data, &lon_len,
+											  &lat_data, &lat_len);
+
+					/* GEOADD key longitude latitude member */
+					argv[0] = "GEOADD";
+					argvlen[0] = 6;
+					argv[1] = fmstate->singleton_key;
+					argvlen[1] = fmstate->singleton_key_len;
+					argv[2] = lon_data;
+					argvlen[2] = lon_len;
 					argv[3] = lat_data;
 					argvlen[3] = lat_len;
 					argv[4] = key_data;
@@ -3980,6 +4036,7 @@ redisExecForeignDelete(EState *estate,
 				break;
 			case PG_REDIS_ZSET_TABLE:
 			case PG_REDIS_GEO_TABLE:
+			case PG_REDIS_GEO4326_TABLE:
 				/* geo sets are zsets internally, so ZREM works for them too */
 				reply = redis_command(context, "ZREM",
 									  fmstate->singleton_key, fmstate->singleton_key_len,
@@ -4066,6 +4123,108 @@ redis_geo_fill_missing_coords(redisContext *context, RedisFdwModifyState *fmstat
 		*lat_len = pos->element[1]->len;
 	}
 	freeReplyObject(posreply);
+}
+
+/*
+ * redis_format_geo4326_point
+ *		Format a GEOPOS/GEOSEARCH longitude/latitude pair as EWKT text,
+ *		e.g. "SRID=4326;POINT(13.361389 38.115556)", so it can be cast
+ *		directly to a PostGIS geometry(Point, 4326).
+ */
+static char *
+redis_format_geo4326_point(const char *long_str, const char *lat_str)
+{
+	size_t		len = strlen(long_str) + strlen(lat_str) + 32;
+	char	   *result = palloc(len);
+
+	snprintf(result, len, "SRID=4326;POINT(%s %s)", long_str, lat_str);
+	return result;
+}
+
+/*
+ * redis_parse_geo4326_point
+ *		Parse EWKT point text, optionally prefixed with "SRID=4326;", into
+ *		separate longitude/latitude text values suitable for GEOADD. Any
+ *		SRID given must be 4326, since that's the coordinate system Redis's
+ *		GEOADD/GEOPOS use.
+ */
+static void
+redis_parse_geo4326_point(const char *text,
+						  char **lon, size_t *lon_len,
+						  char **lat, size_t *lat_len)
+{
+	const char *p = text;
+	char	   *endptr;
+	double		londbl,
+				latdbl;
+
+	while (isspace((unsigned char) *p))
+		p++;
+
+	if (pg_strncasecmp(p, "SRID=", 5) == 0)
+	{
+		long		srid;
+
+		p += 5;
+		srid = strtol(p, &endptr, 10);
+		if (endptr == p || *endptr != ';')
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+					 errmsg("invalid geo4326 point value: \"%s\"", text)));
+		if (srid != 4326)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("unsupported SRID %ld in geo4326 point value: only 4326 is supported", srid)));
+		p = endptr + 1;
+		while (isspace((unsigned char) *p))
+			p++;
+	}
+
+	if (pg_strncasecmp(p, "POINT", 5) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+	p += 5;
+
+	while (isspace((unsigned char) *p))
+		p++;
+	if (*p != '(')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+	p++;
+
+	londbl = strtod(p, &endptr);
+	if (endptr == p)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+	p = endptr;
+
+	while (isspace((unsigned char) *p))
+		p++;
+
+	latdbl = strtod(p, &endptr);
+	if (endptr == p)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+	p = endptr;
+
+	while (isspace((unsigned char) *p))
+		p++;
+	if (*p != ')')
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+
+	*lon = palloc(64);
+	snprintf(*lon, 64, "%.17g", londbl);
+	*lon_len = strlen(*lon);
+
+	*lat = palloc(64);
+	snprintf(*lat, 64, "%.17g", latdbl);
+	*lat_len = strlen(*lat);
 }
 
 /*
@@ -4211,6 +4370,15 @@ redisExecForeignUpdate(EState *estate,
 				newlong_len = strlen(newlong);
 			}
 		}
+		else if (fmstate->table_type == PG_REDIS_GEO4326_TABLE)
+		{
+			/* singleton geo4326: column 2 is the EWKT point text */
+			char	   *point_text = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
+
+			redis_parse_geo4326_point(point_text,
+									  &newlong, &newlong_len,
+									  &newlat, &newlat_len);
+		}
 		else if (fmstate->singleton_key ||
 				 fmstate->table_type == PG_REDIS_SCALAR_TABLE)
 		{
@@ -4329,6 +4497,7 @@ redisExecForeignUpdate(EState *estate,
 					break;
 				case PG_REDIS_ZSET_TABLE:
 				case PG_REDIS_GEO_TABLE:
+				case PG_REDIS_GEO4326_TABLE:
 					/* geo sets are zsets internally, so ZRANK works too */
 					ereply = redis_command2(context, "ZRANK",
 											fmstate->singleton_key, strlen(fmstate->singleton_key),
@@ -4349,7 +4518,8 @@ redisExecForeignUpdate(EState *estate,
 							"failed checking key existence %s", keyval);
 
 				if (fmstate->table_type != PG_REDIS_ZSET_TABLE &&
-					fmstate->table_type != PG_REDIS_GEO_TABLE)
+					fmstate->table_type != PG_REDIS_GEO_TABLE &&
+					fmstate->table_type != PG_REDIS_GEO4326_TABLE)
 					ok = ereply->type == REDIS_REPLY_INTEGER &&
 						ereply->integer == 0;
 				else
@@ -4554,6 +4724,7 @@ redisExecForeignUpdate(EState *estate,
 						freeReplyObject(ereply);
 					}
 					break;
+				case PG_REDIS_GEO4326_TABLE:
 				case PG_REDIS_GEO_TABLE:
 					{
 						const char *argv[5];
@@ -4695,7 +4866,8 @@ redisExecForeignUpdate(EState *estate,
 									   fmstate->singleton_key, fmstate->singleton_key_len,
 									   key_data, key_len, val_data, val_len);
 			}
-			else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
+			else if (fmstate->table_type == PG_REDIS_GEO_TABLE ||
+					 fmstate->table_type == PG_REDIS_GEO4326_TABLE)
 			{
 				const char *argv[5];
 				size_t		argvlen[5];

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -3590,8 +3590,14 @@ redisExecForeignInsert(EState *estate,
 		}
 		else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
 		{
-			extra = slot_getattr(slot, 2, &isnull);	/* lat */
-			extra2 = slot_getattr(slot, 3, &isnull);	/* long */
+			bool		isnull2;
+
+			extra = slot_getattr(slot, 2, &isnull);		/* lat */
+			extra2 = slot_getattr(slot, 3, &isnull2);	/* long */
+			if (isnull || isnull2)
+				ereport(ERROR,
+						(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+						 errmsg("cannot insert NULL coordinates into a Redis geo table")));
 		}
 
 		switch (fmstate->table_type)

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -4769,13 +4769,17 @@ redisExecForeignUpdate(EState *estate,
 													  &newlat, &newlat_len,
 													  &newlong, &newlong_len);
 
-						ereply = redis_command(context, "ZREM",
-											   fmstate->singleton_key, fmstate->singleton_key_len,
-											   NULL, 0, key_data, key_len);
-						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
-									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
-									"removing set element %s", keyval);
-						freeReplyObject(ereply);
+						/*
+						 * Add the new member before removing the old one.
+						 * Redis gives us no transaction to roll back, so if
+						 * GEOADD rejects the coordinates the ZREM must not
+						 * already have happened - otherwise a failed UPDATE
+						 * silently deletes the row. The reverse order is
+						 * safe: the new member is known to differ from the
+						 * old one, and to not exist yet, because we only get
+						 * here after the key comparison and the ZRANK
+						 * duplicate check above.
+						 */
 
 						/* GEOADD key longitude latitude member */
 						argv[0] = "GEOADD";
@@ -4792,6 +4796,14 @@ redisExecForeignUpdate(EState *estate,
 						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
 									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 									"setting element %s", newkey);
+						freeReplyObject(ereply);
+
+						ereply = redis_command(context, "ZREM",
+											   fmstate->singleton_key, fmstate->singleton_key_len,
+											   NULL, 0, key_data, key_len);
+						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+									"removing set element %s", keyval);
 						freeReplyObject(ereply);
 					}
 					break;

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -124,7 +124,8 @@ typedef enum
 	PG_REDIS_HASH_TABLE,
 	PG_REDIS_LIST_TABLE,
 	PG_REDIS_SET_TABLE,
-	PG_REDIS_ZSET_TABLE
+	PG_REDIS_ZSET_TABLE,
+	PG_REDIS_GEO_TABLE
 } redis_table_type;
 
 /*
@@ -403,6 +404,12 @@ static inline bool redis_zset_has_scores_column(redis_table_type table_type,
 									const char *singleton_key, int natts);
 static void get_datum_as_string(Datum datum, redis_val_type valtype,
 						FmgrInfo *flinfo, const char **data, size_t *len);
+static void redis_geo_fill_missing_coords(redisContext *context,
+						RedisFdwModifyState *fmstate,
+						const char *member_data, size_t member_len,
+						char *keyval,
+						char **lat, size_t *lat_len,
+						char **lon, size_t *lon_len);
 
 /* Connection cache functions */
 static void redis_conn_cache_init(void);
@@ -1115,11 +1122,13 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 				tabletype = PG_REDIS_SET_TABLE;
 			else if (strcmp(typeval, "zset") == 0)
 				tabletype = PG_REDIS_ZSET_TABLE;
+			else if (strcmp(typeval, "geo") == 0)
+				tabletype = PG_REDIS_GEO_TABLE;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid tabletype (%s) - must be hash, "
-								"list, set or zset", typeval)));
+								"list, set, zset or geo", typeval)));
 		}
 	}
 
@@ -1240,11 +1249,13 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 				table_options->table_type = PG_REDIS_SET_TABLE;
 			else if (strcmp(typeval, "zset") == 0)
 				table_options->table_type = PG_REDIS_ZSET_TABLE;
+			else if (strcmp(typeval, "geo") == 0)
+				table_options->table_type = PG_REDIS_GEO_TABLE;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid tabletype (%s) - must be hash, "
-								"list, set or zset", typeval)));
+								"list, set, zset or geo", typeval)));
 		}
 	}
 
@@ -1304,6 +1315,8 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 				(natts == 1 || natts == 2) : (natts == 2 || natts == 3);
 		else if (table_options->table_type == PG_REDIS_HASH_TABLE)
 			valid = (natts == 2);
+		else if (table_options->table_type == PG_REDIS_GEO_TABLE)
+			valid = (natts == 3);	/* member, latitude, longitude */
 		else	/* PG_REDIS_SCALAR_TABLE, PG_REDIS_SET_TABLE, PG_REDIS_LIST_TABLE */
 			valid = table_options->singleton_key ? (natts == 1) : (natts == 2);
 
@@ -1319,6 +1332,13 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("table has a dropped column among the columns this table type uses")));
 	}
+
+	if (table_options->table_type == PG_REDIS_GEO_TABLE &&
+		!table_options->singleton_key)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("geo tables are only supported with singleton_key")
+				 ));
 }
 
 /*
@@ -1422,6 +1442,8 @@ redisGetForeignRelSize(PlannerInfo *root,
 				reply = redisCommand(context, "SCARD %s", table_options.singleton_key);
 				break;
 			case PG_REDIS_ZSET_TABLE:
+			case PG_REDIS_GEO_TABLE:
+				/* geo sets are zsets internally, so ZCARD works for them too */
 				reply = redisCommand(context, "ZCARD %s", table_options.singleton_key);
 				break;
 			default:
@@ -1756,6 +1778,16 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 				break;
 			case PG_REDIS_ZSET_TABLE:
 				reply = redisCommand(context, "ZRANGEBYSCORE %s -inf inf WITHSCORES", table_options.singleton_key);
+				break;
+			case PG_REDIS_GEO_TABLE:
+				/*
+				 * There's no direct "get everything" command for geo sets,
+				 * so search a box large enough to cover the whole Earth
+				 * from an arbitrary origin.
+				 */
+				reply = redisCommand(context,
+									 "GEOSEARCH %s FROMLONLAT 0 0 BYBOX 40075 40075 km ASC WITHCOORD",
+									 table_options.singleton_key);
 				break;
 			default:
 				;
@@ -2263,6 +2295,8 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 	char	   *data = NULL;
 	size_t		key_len = 0;
 	size_t		data_len = 0;
+	char	   *lat_str = NULL;
+	char	   *long_str = NULL;
 	char	  **values;
 	HeapTuple	tuple;
 	bool		has_bytea = false;
@@ -2342,6 +2376,22 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 								errmsg("not expecting an array for a single hash property: %s", festate->qual_value)));
 				break;
 		}
+	}
+	else if (festate->table_type == PG_REDIS_GEO_TABLE &&
+			festate->row < festate->reply->elements)
+	{
+		/*
+		 * GEOSEARCH ... WITHCOORD replies with one entry per member:
+		 * [member, [longitude, latitude]]
+		 */
+		redisReply *entry = festate->reply->element[festate->row];
+		redisReply *coord = entry->element[1];
+
+		found = true;
+		key = entry->element[0]->str;
+		long_str = coord->element[0]->str;
+		lat_str = coord->element[1]->str;
+		festate->row++;
 	}
 	else if (festate->row < festate->reply->elements)
 	{
@@ -2433,6 +2483,15 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 			}
 
 			tuple = heap_form_tuple(festate->tupdesc, datums, nulls);
+			ExecStoreHeapTuple(tuple, slot, false);
+		}
+		else if (festate->table_type == PG_REDIS_GEO_TABLE)
+		{
+			values = (char **) palloc(sizeof(char *) * 3);
+			values[0] = key;
+			values[1] = lat_str;
+			values[2] = long_str;
+			tuple = BuildTupleFromCStrings(festate->attinmeta, values);
 			ExecStoreHeapTuple(tuple, slot, false);
 		}
 		else
@@ -3049,13 +3108,30 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 	{
 		if (table_options.singleton_key)
 		{
+			int			expected_cols;
+
 			if (table_options.table_type == PG_REDIS_ZSET_TABLE && fmstate->p_nums < 2)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("operation not supported for singleton zset "
 								"table without priorities column")
 						 ));
-			else if (fmstate->p_nums != ((table_options.table_type == PG_REDIS_HASH_TABLE || table_options.table_type == PG_REDIS_ZSET_TABLE) ? 2 : 1))
+
+			switch (table_options.table_type)
+			{
+				case PG_REDIS_HASH_TABLE:
+				case PG_REDIS_ZSET_TABLE:
+					expected_cols = 2;
+					break;
+				case PG_REDIS_GEO_TABLE:
+					expected_cols = 3;
+					break;
+				default:
+					expected_cols = 1;
+					break;
+			}
+
+			if (fmstate->p_nums != expected_cols)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("table has incorrect number of columns: %d for type %d", fmstate->p_nums, table_options.table_type)
@@ -3359,11 +3435,13 @@ redisExecForeignInsert(EState *estate,
 	if (fmstate->singleton_key)
 	{
 		Datum		extra = 0;
+		Datum		extra2 = 0;
 
 		/*
 		 * Check if key is there using EXISTS / HEXISTS / SISMEMBER / ZRANK.
 		 * It is not an error for a list type singleton as they don't have to
-		 * be unique.
+		 * be unique. Geo sets are zsets internally, so ZRANK works for them
+		 * too.
 		 */
 
 		switch (fmstate->table_type)
@@ -3383,6 +3461,7 @@ redisExecForeignInsert(EState *estate,
 									   NULL, 0, key_data, key_len);
 				break;
 			case PG_REDIS_ZSET_TABLE:
+			case PG_REDIS_GEO_TABLE:
 				sreply = redis_command(context, "ZRANK",		/* n or nil */
 									   fmstate->singleton_key, fmstate->singleton_key_len,
 									   NULL, 0, key_data, key_len);
@@ -3400,7 +3479,8 @@ redisExecForeignInsert(EState *estate,
 						ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 						"failed checking key existence", NULL);
 
-			if (fmstate->table_type != PG_REDIS_ZSET_TABLE)
+			if (fmstate->table_type != PG_REDIS_ZSET_TABLE &&
+				fmstate->table_type != PG_REDIS_GEO_TABLE)
 				ok = sreply->type == REDIS_REPLY_INTEGER &&
 					sreply->integer == 0;
 			else
@@ -3434,6 +3514,11 @@ redisExecForeignInsert(EState *estate,
 						(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 						 errmsg("cannot insert NULL value into a Redis table")
 						 ));
+		}
+		else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
+		{
+			extra = slot_getattr(slot, 2, &isnull);	/* lat */
+			extra2 = slot_getattr(slot, 3, &isnull);	/* long */
 		}
 
 		switch (fmstate->table_type)
@@ -3476,6 +3561,34 @@ redisExecForeignInsert(EState *estate,
 					sreply = redis_command(context, "ZADD",
 										   fmstate->singleton_key, fmstate->singleton_key_len,
 										   extra_data, extra_len, key_data, key_len);
+				}
+				break;
+			case PG_REDIS_GEO_TABLE:
+				{
+					const char *lat_data,
+							   *long_data;
+					size_t		lat_len,
+								long_len;
+					const char *argv[5];
+					size_t		argvlen[5];
+
+					get_datum_as_string(extra, fmstate->val_types[1],
+										&fmstate->p_flinfo[1], &lat_data, &lat_len);
+					get_datum_as_string(extra2, fmstate->val_types[2],
+										&fmstate->p_flinfo[2], &long_data, &long_len);
+
+					/* GEOADD key longitude latitude member */
+					argv[0] = "GEOADD";
+					argvlen[0] = 6;
+					argv[1] = fmstate->singleton_key;
+					argvlen[1] = fmstate->singleton_key_len;
+					argv[2] = long_data;
+					argvlen[2] = long_len;
+					argv[3] = lat_data;
+					argvlen[3] = lat_len;
+					argv[4] = key_data;
+					argvlen[4] = key_len;
+					sreply = redisCommandArgv(context, 5, argv, argvlen);
 				}
 				break;
 			default:
@@ -3866,6 +3979,8 @@ redisExecForeignDelete(EState *estate,
 									  NULL, 0, key_data, key_len);
 				break;
 			case PG_REDIS_ZSET_TABLE:
+			case PG_REDIS_GEO_TABLE:
+				/* geo sets are zsets internally, so ZREM works for them too */
 				reply = redis_command(context, "ZREM",
 									  fmstate->singleton_key, fmstate->singleton_key_len,
 									  NULL, 0, key_data, key_len);
@@ -3906,6 +4021,54 @@ redisExecForeignDelete(EState *estate,
 }
 
 /*
+ * redis_geo_fill_missing_coords
+ *		If either lat or lon is not already set (i.e. that coordinate wasn't
+ *		part of this UPDATE), fetch the member's current position with
+ *		GEOPOS and fill in whichever of the two is missing.
+ */
+static void
+redis_geo_fill_missing_coords(redisContext *context, RedisFdwModifyState *fmstate,
+							  const char *member_data, size_t member_len,
+							  char *keyval,
+							  char **lat, size_t *lat_len,
+							  char **lon, size_t *lon_len)
+{
+	redisReply *posreply;
+	redisReply *pos;
+
+	if (*lat && *lon)
+		return;
+
+	posreply = redis_command(context, "GEOPOS",
+							 fmstate->singleton_key, fmstate->singleton_key_len,
+							 NULL, 0, member_data, member_len);
+	check_reply(posreply, context, RTYPE(REDIS_REPLY_ARRAY),
+				ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+				"getting position for key %s", keyval);
+
+	pos = posreply->element[0];
+	if (pos->type != REDIS_REPLY_ARRAY)
+	{
+		freeReplyObject(posreply);
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
+				 errmsg("could not find current position for key %s", keyval)));
+	}
+
+	if (!*lon)
+	{
+		*lon = pstrdup(pos->element[0]->str);
+		*lon_len = pos->element[0]->len;
+	}
+	if (!*lat)
+	{
+		*lat = pstrdup(pos->element[1]->str);
+		*lat_len = pos->element[1]->len;
+	}
+	freeReplyObject(posreply);
+}
+
+/*
  * redisExecForeignUpdate
  *		Update one row in a foreign table
  */
@@ -3928,6 +4091,10 @@ redisExecForeignUpdate(EState *estate,
 	size_t		newkey_len;			/* new key length */
 	char	   *newval = NULL;
 	size_t		newval_len = 0;
+	char	   *newlat = NULL;			/* singleton geo latitude */
+	size_t		newlat_len = 0;
+	char	   *newlong = NULL;		/* singleton geo longitude */
+	size_t		newlong_len = 0;
 	bool		isNull;
 	ListCell   *lc = NULL;
 	int			flslot = 1;
@@ -4028,6 +4195,20 @@ redisExecForeignUpdate(EState *estate,
 				newkey = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
 				newkey_len = strlen(newkey);
 				newkey_data = newkey;
+			}
+		}
+		else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
+		{
+			/* singleton geo: column 2 is latitude, column 3 is longitude */
+			if (attnum == 2)
+			{
+				newlat = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
+				newlat_len = strlen(newlat);
+			}
+			else
+			{
+				newlong = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
+				newlong_len = strlen(newlong);
 			}
 		}
 		else if (fmstate->singleton_key ||
@@ -4147,6 +4328,8 @@ redisExecForeignUpdate(EState *estate,
 											newkey_data, newkey_len);
 					break;
 				case PG_REDIS_ZSET_TABLE:
+				case PG_REDIS_GEO_TABLE:
+					/* geo sets are zsets internally, so ZRANK works too */
 					ereply = redis_command2(context, "ZRANK",
 											fmstate->singleton_key, strlen(fmstate->singleton_key),
 											newkey_data, newkey_len);
@@ -4165,7 +4348,8 @@ redisExecForeignUpdate(EState *estate,
 							ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 							"failed checking key existence %s", keyval);
 
-				if (fmstate->table_type != PG_REDIS_ZSET_TABLE)
+				if (fmstate->table_type != PG_REDIS_ZSET_TABLE &&
+					fmstate->table_type != PG_REDIS_GEO_TABLE)
 					ok = ereply->type == REDIS_REPLY_INTEGER &&
 						ereply->integer == 0;
 				else
@@ -4370,6 +4554,42 @@ redisExecForeignUpdate(EState *estate,
 						freeReplyObject(ereply);
 					}
 					break;
+				case PG_REDIS_GEO_TABLE:
+					{
+						const char *argv[5];
+						size_t		argvlen[5];
+
+						redis_geo_fill_missing_coords(context, fmstate,
+													  key_data, key_len, keyval,
+													  &newlat, &newlat_len,
+													  &newlong, &newlong_len);
+
+						ereply = redis_command(context, "ZREM",
+											   fmstate->singleton_key, fmstate->singleton_key_len,
+											   NULL, 0, key_data, key_len);
+						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+									"removing set element %s", keyval);
+						freeReplyObject(ereply);
+
+						/* GEOADD key longitude latitude member */
+						argv[0] = "GEOADD";
+						argvlen[0] = 6;
+						argv[1] = fmstate->singleton_key;
+						argvlen[1] = fmstate->singleton_key_len;
+						argv[2] = newlong;
+						argvlen[2] = newlong_len;
+						argv[3] = newlat;
+						argvlen[3] = newlat_len;
+						argv[4] = newkey_data;
+						argvlen[4] = newkey_len;
+						ereply = redisCommandArgv(context, 5, argv, argvlen);
+						check_reply(ereply, context, RTYPE(REDIS_REPLY_INTEGER),
+									ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
+									"setting element %s", newkey);
+						freeReplyObject(ereply);
+					}
+					break;
 				case PG_REDIS_HASH_TABLE:
 					{
 						char	   *nval = newval;
@@ -4430,7 +4650,7 @@ redisExecForeignUpdate(EState *estate,
 			}
 		}
 	}	/* no key update */
-	else if (newval || value_is_bytea)
+	else if (newval || value_is_bytea || newlat || newlong)
 	{
 		if (!fmstate->singleton_key)
 		{
@@ -4474,6 +4694,29 @@ redisExecForeignUpdate(EState *estate,
 				ereply = redis_command(context, "HSET",
 									   fmstate->singleton_key, fmstate->singleton_key_len,
 									   key_data, key_len, val_data, val_len);
+			}
+			else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
+			{
+				const char *argv[5];
+				size_t		argvlen[5];
+
+				redis_geo_fill_missing_coords(context, fmstate,
+											  key_data, key_len, keyval,
+											  &newlat, &newlat_len,
+											  &newlong, &newlong_len);
+
+				/* GEOADD key longitude latitude member (overwrites in place) */
+				argv[0] = "GEOADD";
+				argvlen[0] = 6;
+				argv[1] = fmstate->singleton_key;
+				argvlen[1] = fmstate->singleton_key_len;
+				argv[2] = newlong;
+				argvlen[2] = newlong_len;
+				argv[3] = newlat;
+				argvlen[3] = newlat_len;
+				argv[4] = key_data;
+				argvlen[4] = key_len;
+				ereply = redisCommandArgv(context, 5, argv, argvlen);
 			}
 			else
 				elog(ERROR, "impossible update");		/* should not happen */

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -2446,9 +2446,37 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 		/*
 		 * GEOSEARCH ... WITHCOORD replies with one entry per member:
 		 * [member, [longitude, latitude]]
+		 *
+		 * Verify that shape before indexing into it. check_reply only
+		 * rejects a NULL reply and REDIS_REPLY_ERROR, so nothing has
+		 * established it yet, and a reply element that isn't an array has
+		 * element == NULL - an unchecked entry->element[1] would
+		 * dereference NULL and crash the backend instead of raising an
+		 * error. The tests are ordered so that || short-circuits each
+		 * arity check before the index that depends on it.
+		 *
+		 * Requiring strings at the leaves assumes RESP2, which is what we
+		 * get because we never send HELLO 3. Under RESP3 the coordinates
+		 * come back as REDIS_REPLY_DOUBLE and this test has to widen.
 		 */
 		redisReply *entry = festate->reply->element[festate->row];
-		redisReply *coord = entry->element[1];
+		redisReply *coord;
+
+		if (entry->type != REDIS_REPLY_ARRAY || entry->elements != 2 ||
+			entry->element[0]->type != REDIS_REPLY_STRING ||
+			entry->element[1]->type != REDIS_REPLY_ARRAY ||
+			entry->element[1]->elements != 2 ||
+			entry->element[1]->element[0]->type != REDIS_REPLY_STRING ||
+			entry->element[1]->element[1]->type != REDIS_REPLY_STRING)
+		{
+			freeReplyObject(festate->reply);
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
+					 errmsg("unexpected reply shape from GEOSEARCH for key %s",
+							festate->singleton_key)));
+		}
+
+		coord = entry->element[1];
 
 		found = true;
 		key = entry->element[0]->str;
@@ -4140,13 +4168,41 @@ redis_geo_fill_missing_coords(redisContext *context, RedisFdwModifyState *fmstat
 				ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION,
 				"getting position for key %s", keyval);
 
-	pos = posreply->element[0];
-	if (pos->type != REDIS_REPLY_ARRAY)
+	/*
+	 * check_reply only rejects a NULL reply and REDIS_REPLY_ERROR, so the
+	 * shape is still unverified: GEOPOS answers with an array carrying one
+	 * entry per member asked about.
+	 */
+	if (posreply->type != REDIS_REPLY_ARRAY || posreply->elements < 1)
 	{
 		freeReplyObject(posreply);
 		ereport(ERROR,
 				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
+				 errmsg("unexpected reply shape from GEOPOS for key %s", keyval)));
+	}
+
+	pos = posreply->element[0];
+	if (pos->type != REDIS_REPLY_ARRAY)
+	{
+		/* a nil entry means the member is no longer in the index */
+		freeReplyObject(posreply);
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
 				 errmsg("could not find current position for key %s", keyval)));
+	}
+
+	/*
+	 * RESP2 returns the coordinates as strings; see the GEOSEARCH path in
+	 * redisIterateForeignScan for why that assumption is safe here.
+	 */
+	if (pos->elements != 2 ||
+		pos->element[0]->type != REDIS_REPLY_STRING ||
+		pos->element[1]->type != REDIS_REPLY_STRING)
+	{
+		freeReplyObject(posreply);
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
+				 errmsg("unexpected reply shape from GEOPOS for key %s", keyval)));
 	}
 
 	if (!*lon)

--- a/redis_fdw.c
+++ b/redis_fdw.c
@@ -126,8 +126,7 @@ typedef enum
 	PG_REDIS_LIST_TABLE,
 	PG_REDIS_SET_TABLE,
 	PG_REDIS_ZSET_TABLE,
-	PG_REDIS_GEO_TABLE,
-	PG_REDIS_GEO4326_TABLE
+	PG_REDIS_GEO_TABLE
 } redis_table_type;
 
 /*
@@ -153,6 +152,9 @@ typedef struct redisTableOptions
 	char	   *keyset;
 	char	   *singleton_key;
 	redis_table_type table_type;
+	bool		geo_ewkt;		/* geo shape: (text, text) EWKT point vs
+								 * (text, double precision, double
+								 * precision) lat/long */
 } redisTableOptions;
 
 typedef struct
@@ -193,6 +195,7 @@ typedef struct RedisFdwExecutionState
 	char	   *qual_value;
 	char	   *singleton_key;
 	redis_table_type table_type;
+	bool		geo_ewkt;
 	char	   *cursor_search_string;
 	char	   *cursor_id;
 	MemoryContext mctxt;
@@ -220,6 +223,7 @@ typedef struct RedisFdwModifyState
 	size_t		singleton_key_len;
 	Relation	rel;
 	redis_table_type table_type;
+	bool		geo_ewkt;
 	List	   *target_attrs;
 	int		   *targetDims;
 	int			p_nums;
@@ -412,10 +416,10 @@ static void redis_geo_fill_missing_coords(redisContext *context,
 						char *keyval,
 						char **lat, size_t *lat_len,
 						char **lon, size_t *lon_len);
-static char *redis_format_geo4326_point(const char *long_str, const char *lat_str);
-static void redis_parse_geo4326_point(const char *text,
-						char **lon, size_t *lon_len,
-						char **lat, size_t *lat_len);
+static char *redis_format_ewkt_point(const char *long_str, const char *lat_str);
+static void redis_parse_ewkt_point(const char *text,
+								   char **lon, size_t *lon_len,
+								   char **lat, size_t *lat_len);
 
 /* Connection cache functions */
 static void redis_conn_cache_init(void);
@@ -1130,13 +1134,11 @@ redis_fdw_validator(PG_FUNCTION_ARGS)
 				tabletype = PG_REDIS_ZSET_TABLE;
 			else if (strcmp(typeval, "geo") == 0)
 				tabletype = PG_REDIS_GEO_TABLE;
-			else if (strcmp(typeval, "geo4326") == 0)
-				tabletype = PG_REDIS_GEO4326_TABLE;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid tabletype (%s) - must be hash, "
-								"list, set, zset, geo or geo4326", typeval)));
+								"list, set, zset or geo", typeval)));
 		}
 	}
 
@@ -1202,6 +1204,7 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 	table_options->keyset = NULL;
 	table_options->singleton_key = NULL;
 	table_options->table_type = PG_REDIS_SCALAR_TABLE;
+	table_options->geo_ewkt = false;
 
 	/*
 	 * Extract options from FDW objects. We only need to worry about server
@@ -1259,13 +1262,11 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 				table_options->table_type = PG_REDIS_ZSET_TABLE;
 			else if (strcmp(typeval, "geo") == 0)
 				table_options->table_type = PG_REDIS_GEO_TABLE;
-			else if (strcmp(typeval, "geo4326") == 0)
-				table_options->table_type = PG_REDIS_GEO4326_TABLE;
 			else
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("invalid tabletype (%s) - must be hash, "
-								"list, set, zset, geo or geo4326", typeval)));
+								"list, set, zset or geo", typeval)));
 		}
 	}
 
@@ -1326,11 +1327,60 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 		else if (table_options->table_type == PG_REDIS_HASH_TABLE)
 			valid = (natts == 2);
 		else if (table_options->table_type == PG_REDIS_GEO_TABLE)
-			valid = (natts == 3);	/* member, latitude, longitude */
-		else if (table_options->table_type == PG_REDIS_GEO4326_TABLE)
-			valid = (natts == 2);	/* member, EWKT point */
+			valid = (natts == 2 || natts == 3);
 		else	/* PG_REDIS_SCALAR_TABLE, PG_REDIS_SET_TABLE, PG_REDIS_LIST_TABLE */
 			valid = table_options->singleton_key ? (natts == 1) : (natts == 2);
+
+		if (valid && leading &&
+			table_options->table_type == PG_REDIS_GEO_TABLE)
+		{
+			/*
+			 * Pick the geo shape from the declared columns: (text, text) is
+			 * an EWKT point, (text, float8, float8) is separate lat/long.
+			 *
+			 * Indexing by position is safe here only because of the
+			 * "leading &&" conjunct in the enclosing if, which skips this
+			 * discrimination entirely unless the live columns are the
+			 * leading ones. (The !leading ereport further down cannot
+			 * provide that guarantee: it runs after this block.) That
+			 * conjunct means positions 0..natts-1 are live, so their
+			 * atttypid values are real - a dropped column carries
+			 * InvalidOid, and reading one here would silently misclassify
+			 * the table. Do not drop it from the condition.
+			 */
+			/*
+			 * classify_type() answers REDIS_VAL_TEXT for varchar and
+			 * bpchar as well as text, so those are accepted here too.
+			 * The error message below names only text, since that is
+			 * the shape worth documenting; the leniency is deliberate.
+			 */
+			/*
+			 * The member column has to be text too. The error below has
+			 * always advertised (text, ...), but nothing enforced it, which
+			 * left a bytea member column declarable - and it would then take
+			 * the bytea tuple path, which fills every column from data. A geo
+			 * scan never populates data; its coordinates arrive separately.
+			 */
+			bool		member_ok =
+				classify_type(TupleDescAttr(tupdesc, 0)->atttypid) == REDIS_VAL_TEXT;
+
+			if (member_ok && natts == 2 &&
+				classify_type(TupleDescAttr(tupdesc, 1)->atttypid) == REDIS_VAL_TEXT)
+				table_options->geo_ewkt = true;
+			else if (member_ok && natts == 3 &&
+					 TupleDescAttr(tupdesc, 1)->atttypid == FLOAT8OID &&
+					 TupleDescAttr(tupdesc, 2)->atttypid == FLOAT8OID)
+				table_options->geo_ewkt = false;
+			else
+			{
+				table_close(rel, NoLock);
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("geo tables must have columns (text, text) for an "
+								"EWKT point, or (text, double precision, double "
+								"precision) for latitude/longitude")));
+			}
+		}
 
 		table_close(rel, NoLock);
 
@@ -1345,8 +1395,7 @@ redisGetOptions(Oid foreigntableid, redisTableOptions *table_options)
 					 errmsg("table has a dropped column among the columns this table type uses")));
 	}
 
-	if ((table_options->table_type == PG_REDIS_GEO_TABLE ||
-		 table_options->table_type == PG_REDIS_GEO4326_TABLE) &&
+	if (table_options->table_type == PG_REDIS_GEO_TABLE &&
 		!table_options->singleton_key)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1456,7 +1505,6 @@ redisGetForeignRelSize(PlannerInfo *root,
 				break;
 			case PG_REDIS_ZSET_TABLE:
 			case PG_REDIS_GEO_TABLE:
-			case PG_REDIS_GEO4326_TABLE:
 				/* geo sets are zsets internally, so ZCARD works for them too */
 				reply = redisCommand(context, "ZCARD %s", table_options.singleton_key);
 				break;
@@ -1677,6 +1725,7 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 	festate->keyset = table_options.keyset;
 	festate->singleton_key = table_options.singleton_key;
 	festate->table_type = table_options.table_type;
+	festate->geo_ewkt = table_options.geo_ewkt;
 	festate->cursor_id = NULL;
 	festate->cursor_search_string = NULL;
 
@@ -1794,7 +1843,6 @@ redisBeginForeignScan(ForeignScanState *node, int eflags)
 				reply = redisCommand(context, "ZRANGEBYSCORE %s -inf inf WITHSCORES", table_options.singleton_key);
 				break;
 			case PG_REDIS_GEO_TABLE:
-			case PG_REDIS_GEO4326_TABLE:
 				/*
 				 * There's no direct "get everything" command for geo sets,
 				 * so search a box large enough to cover the whole Earth
@@ -2392,8 +2440,7 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 				break;
 		}
 	}
-	else if ((festate->table_type == PG_REDIS_GEO_TABLE ||
-			  festate->table_type == PG_REDIS_GEO4326_TABLE) &&
+	else if (festate->table_type == PG_REDIS_GEO_TABLE &&
 			 festate->row < festate->reply->elements)
 	{
 		/*
@@ -2501,7 +2548,7 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 			tuple = heap_form_tuple(festate->tupdesc, datums, nulls);
 			ExecStoreHeapTuple(tuple, slot, false);
 		}
-		else if (festate->table_type == PG_REDIS_GEO_TABLE)
+		else if (festate->table_type == PG_REDIS_GEO_TABLE && !festate->geo_ewkt)
 		{
 			values = (char **) palloc(sizeof(char *) * 3);
 			values[0] = key;
@@ -2510,11 +2557,13 @@ redisIterateForeignScanSingleton(ForeignScanState *node)
 			tuple = BuildTupleFromCStrings(festate->attinmeta, values);
 			ExecStoreHeapTuple(tuple, slot, false);
 		}
-		else if (festate->table_type == PG_REDIS_GEO4326_TABLE)
+		else if (festate->table_type == PG_REDIS_GEO_TABLE && festate->geo_ewkt)
 		{
 			values = (char **) palloc(sizeof(char *) * 2);
 			values[0] = key;
-			values[1] = redis_format_geo4326_point(long_str, lat_str);
+			values[1] = redis_format_ewkt_point(long_str, lat_str);
+			tuple = BuildTupleFromCStrings(festate->attinmeta, values);
+			ExecStoreHeapTuple(tuple, slot, false);
 		}
 		else
 		{
@@ -2981,6 +3030,7 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 	fmstate->singleton_key = table_options.singleton_key;
 	fmstate->singleton_key_len = table_options.singleton_key ? strlen(table_options.singleton_key) : 0;
 	fmstate->table_type = table_options.table_type;
+	fmstate->geo_ewkt = table_options.geo_ewkt;
 	fmstate->target_attrs = (List *) list_nth(fdw_private, 0);
 
 	n_attrs = list_length(fmstate->target_attrs);
@@ -3143,11 +3193,10 @@ redisBeginForeignModify(ModifyTableState *mtstate,
 			{
 				case PG_REDIS_HASH_TABLE:
 				case PG_REDIS_ZSET_TABLE:
-				case PG_REDIS_GEO4326_TABLE:
 					expected_cols = 2;
 					break;
 				case PG_REDIS_GEO_TABLE:
-					expected_cols = 3;
+					expected_cols = table_options.geo_ewkt ? 2 : 3;
 					break;
 				default:
 					expected_cols = 1;
@@ -3485,7 +3534,6 @@ redisExecForeignInsert(EState *estate,
 				break;
 			case PG_REDIS_ZSET_TABLE:
 			case PG_REDIS_GEO_TABLE:
-			case PG_REDIS_GEO4326_TABLE:
 				sreply = redis_command(context, "ZRANK",		/* n or nil */
 									   fmstate->singleton_key, fmstate->singleton_key_len,
 									   NULL, 0, key_data, key_len);
@@ -3504,8 +3552,7 @@ redisExecForeignInsert(EState *estate,
 						"failed checking key existence", NULL);
 
 			if (fmstate->table_type != PG_REDIS_ZSET_TABLE &&
-				fmstate->table_type != PG_REDIS_GEO_TABLE &&
-				fmstate->table_type != PG_REDIS_GEO4326_TABLE)
+				fmstate->table_type != PG_REDIS_GEO_TABLE)
 				ok = sreply->type == REDIS_REPLY_INTEGER &&
 					sreply->integer == 0;
 			else
@@ -3532,7 +3579,7 @@ redisExecForeignInsert(EState *estate,
 
 		if (fmstate->table_type == PG_REDIS_ZSET_TABLE ||
 			fmstate->table_type == PG_REDIS_HASH_TABLE ||
-			fmstate->table_type == PG_REDIS_GEO4326_TABLE)
+			(fmstate->table_type == PG_REDIS_GEO_TABLE && fmstate->geo_ewkt))
 		{
 			extra = slot_getattr(slot, 2, &isnull);	/* score / value / point */
 			if (isnull)
@@ -3591,17 +3638,32 @@ redisExecForeignInsert(EState *estate,
 				break;
 			case PG_REDIS_GEO_TABLE:
 				{
-					const char *lat_data,
+					char	   *lat_data,
 							   *long_data;
 					size_t		lat_len,
 								long_len;
 					const char *argv[5];
 					size_t		argvlen[5];
 
-					get_datum_as_string(extra, fmstate->val_types[1],
-										&fmstate->p_flinfo[1], &lat_data, &lat_len);
-					get_datum_as_string(extra2, fmstate->val_types[2],
-										&fmstate->p_flinfo[2], &long_data, &long_len);
+					if (fmstate->geo_ewkt)
+					{
+						char	   *point_text = fmstate->val_types[1] == REDIS_VAL_TEXT ?
+							TextDatumGetCString(extra) :
+							OutputFunctionCall(&fmstate->p_flinfo[1], extra);
+
+						redis_parse_ewkt_point(point_text,
+												&long_data, &long_len,
+												&lat_data, &lat_len);
+					}
+					else
+					{
+						get_datum_as_string(extra, fmstate->val_types[1],
+											&fmstate->p_flinfo[1],
+											(const char **) &lat_data, &lat_len);
+						get_datum_as_string(extra2, fmstate->val_types[2],
+											&fmstate->p_flinfo[2],
+											(const char **) &long_data, &long_len);
+					}
 
 					/* GEOADD key longitude latitude member */
 					argv[0] = "GEOADD";
@@ -3610,36 +3672,6 @@ redisExecForeignInsert(EState *estate,
 					argvlen[1] = fmstate->singleton_key_len;
 					argv[2] = long_data;
 					argvlen[2] = long_len;
-					argv[3] = lat_data;
-					argvlen[3] = lat_len;
-					argv[4] = key_data;
-					argvlen[4] = key_len;
-					sreply = redisCommandArgv(context, 5, argv, argvlen);
-				}
-				break;
-			case PG_REDIS_GEO4326_TABLE:
-				{
-					char	   *point_text = fmstate->val_types[1] == REDIS_VAL_TEXT ?
-						TextDatumGetCString(extra) :
-						OutputFunctionCall(&fmstate->p_flinfo[1], extra);
-					char	   *lon_data,
-							   *lat_data;
-					size_t		lon_len,
-								lat_len;
-					const char *argv[5];
-					size_t		argvlen[5];
-
-					redis_parse_geo4326_point(point_text,
-											  &lon_data, &lon_len,
-											  &lat_data, &lat_len);
-
-					/* GEOADD key longitude latitude member */
-					argv[0] = "GEOADD";
-					argvlen[0] = 6;
-					argv[1] = fmstate->singleton_key;
-					argvlen[1] = fmstate->singleton_key_len;
-					argv[2] = lon_data;
-					argvlen[2] = lon_len;
 					argv[3] = lat_data;
 					argvlen[3] = lat_len;
 					argv[4] = key_data;
@@ -4036,7 +4068,6 @@ redisExecForeignDelete(EState *estate,
 				break;
 			case PG_REDIS_ZSET_TABLE:
 			case PG_REDIS_GEO_TABLE:
-			case PG_REDIS_GEO4326_TABLE:
 				/* geo sets are zsets internally, so ZREM works for them too */
 				reply = redis_command(context, "ZREM",
 									  fmstate->singleton_key, fmstate->singleton_key_len,
@@ -4126,13 +4157,13 @@ redis_geo_fill_missing_coords(redisContext *context, RedisFdwModifyState *fmstat
 }
 
 /*
- * redis_format_geo4326_point
+ * redis_format_ewkt_point
  *		Format a GEOPOS/GEOSEARCH longitude/latitude pair as EWKT text,
  *		e.g. "SRID=4326;POINT(13.361389 38.115556)", so it can be cast
  *		directly to a PostGIS geometry(Point, 4326).
  */
 static char *
-redis_format_geo4326_point(const char *long_str, const char *lat_str)
+redis_format_ewkt_point(const char *long_str, const char *lat_str)
 {
 	size_t		len = strlen(long_str) + strlen(lat_str) + 32;
 	char	   *result = palloc(len);
@@ -4142,16 +4173,16 @@ redis_format_geo4326_point(const char *long_str, const char *lat_str)
 }
 
 /*
- * redis_parse_geo4326_point
+ * redis_parse_ewkt_point
  *		Parse EWKT point text, optionally prefixed with "SRID=4326;", into
  *		separate longitude/latitude text values suitable for GEOADD. Any
  *		SRID given must be 4326, since that's the coordinate system Redis's
  *		GEOADD/GEOPOS use.
  */
 static void
-redis_parse_geo4326_point(const char *text,
-						  char **lon, size_t *lon_len,
-						  char **lat, size_t *lat_len)
+redis_parse_ewkt_point(const char *text,
+					   char **lon, size_t *lon_len,
+					   char **lat, size_t *lat_len)
 {
 	const char *p = text;
 	char	   *endptr;
@@ -4170,11 +4201,11 @@ redis_parse_geo4326_point(const char *text,
 		if (endptr == p || *endptr != ';')
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-					 errmsg("invalid geo4326 point value: \"%s\"", text)));
+					 errmsg("invalid geo point value: \"%s\"", text)));
 		if (srid != 4326)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("unsupported SRID %ld in geo4326 point value: only 4326 is supported", srid)));
+					 errmsg("unsupported SRID %ld in geo point value: only 4326 is supported", srid)));
 		p = endptr + 1;
 		while (isspace((unsigned char) *p))
 			p++;
@@ -4183,7 +4214,7 @@ redis_parse_geo4326_point(const char *text,
 	if (pg_strncasecmp(p, "POINT", 5) != 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+				 errmsg("invalid geo point value: \"%s\"", text)));
 	p += 5;
 
 	while (isspace((unsigned char) *p))
@@ -4191,14 +4222,14 @@ redis_parse_geo4326_point(const char *text,
 	if (*p != '(')
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+				 errmsg("invalid geo point value: \"%s\"", text)));
 	p++;
 
 	londbl = strtod(p, &endptr);
 	if (endptr == p)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+				 errmsg("invalid geo point value: \"%s\"", text)));
 	p = endptr;
 
 	while (isspace((unsigned char) *p))
@@ -4208,7 +4239,7 @@ redis_parse_geo4326_point(const char *text,
 	if (endptr == p)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+				 errmsg("invalid geo point value: \"%s\"", text)));
 	p = endptr;
 
 	while (isspace((unsigned char) *p))
@@ -4216,7 +4247,7 @@ redis_parse_geo4326_point(const char *text,
 	if (*p != ')')
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid geo4326 point value: \"%s\"", text)));
+				 errmsg("invalid geo point value: \"%s\"", text)));
 
 	*lon = palloc(64);
 	snprintf(*lon, 64, "%.17g", londbl);
@@ -4356,6 +4387,15 @@ redisExecForeignUpdate(EState *estate,
 				newkey_data = newkey;
 			}
 		}
+		else if (fmstate->table_type == PG_REDIS_GEO_TABLE && fmstate->geo_ewkt)
+		{
+			/* singleton geo (EWKT shape): column 2 is the EWKT point text */
+			char	   *point_text = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
+
+			redis_parse_ewkt_point(point_text,
+									&newlong, &newlong_len,
+									&newlat, &newlat_len);
+		}
 		else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
 		{
 			/* singleton geo: column 2 is latitude, column 3 is longitude */
@@ -4369,15 +4409,6 @@ redisExecForeignUpdate(EState *estate,
 				newlong = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
 				newlong_len = strlen(newlong);
 			}
-		}
-		else if (fmstate->table_type == PG_REDIS_GEO4326_TABLE)
-		{
-			/* singleton geo4326: column 2 is the EWKT point text */
-			char	   *point_text = OutputFunctionCall(&fmstate->p_flinfo[flslot], datum);
-
-			redis_parse_geo4326_point(point_text,
-									  &newlong, &newlong_len,
-									  &newlat, &newlat_len);
 		}
 		else if (fmstate->singleton_key ||
 				 fmstate->table_type == PG_REDIS_SCALAR_TABLE)
@@ -4497,7 +4528,6 @@ redisExecForeignUpdate(EState *estate,
 					break;
 				case PG_REDIS_ZSET_TABLE:
 				case PG_REDIS_GEO_TABLE:
-				case PG_REDIS_GEO4326_TABLE:
 					/* geo sets are zsets internally, so ZRANK works too */
 					ereply = redis_command2(context, "ZRANK",
 											fmstate->singleton_key, strlen(fmstate->singleton_key),
@@ -4518,8 +4548,7 @@ redisExecForeignUpdate(EState *estate,
 							"failed checking key existence %s", keyval);
 
 				if (fmstate->table_type != PG_REDIS_ZSET_TABLE &&
-					fmstate->table_type != PG_REDIS_GEO_TABLE &&
-					fmstate->table_type != PG_REDIS_GEO4326_TABLE)
+					fmstate->table_type != PG_REDIS_GEO_TABLE)
 					ok = ereply->type == REDIS_REPLY_INTEGER &&
 						ereply->integer == 0;
 				else
@@ -4724,7 +4753,6 @@ redisExecForeignUpdate(EState *estate,
 						freeReplyObject(ereply);
 					}
 					break;
-				case PG_REDIS_GEO4326_TABLE:
 				case PG_REDIS_GEO_TABLE:
 					{
 						const char *argv[5];
@@ -4866,8 +4894,7 @@ redisExecForeignUpdate(EState *estate,
 									   fmstate->singleton_key, fmstate->singleton_key_len,
 									   key_data, key_len, val_data, val_len);
 			}
-			else if (fmstate->table_type == PG_REDIS_GEO_TABLE ||
-					 fmstate->table_type == PG_REDIS_GEO4326_TABLE)
+			else if (fmstate->table_type == PG_REDIS_GEO_TABLE)
 			{
 				const char *argv[5];
 				size_t		argvlen[5];

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -682,6 +682,85 @@ select * from db15_w_1key_zsetx order by key;
 -----
 (0 rows)
 
+-- singleton geo table
+create foreign table db15_w_1key_geo(value text, lat double precision, long double precision)
+       server localredis
+       options (singleton_key 'w_1key_geo', tabletype 'geo', database '15');
+select * from db15_w_1key_geo;
+ value | lat | long 
+-------+-----+------
+(0 rows)
+
+insert into db15_w_1key_geo (value, lat, long) values
+       ('Palermo', 38.115556, 13.361389),
+       ('Catania', 37.502669, 15.087269);
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value  |   lat   |  long   
+---------+---------+---------
+ Catania | 37.5027 | 15.0873
+ Palermo | 38.1156 | 13.3614
+(2 rows)
+
+-- duplicate member is rejected
+insert into db15_w_1key_geo (value, lat, long) values ('Palermo', 0, 0);
+ERROR:  key already exists: Palermo
+-- update just one coordinate - the other must be preserved
+update db15_w_1key_geo set lat = 40 where value = 'Palermo';
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value  |   lat   |  long   
+---------+---------+---------
+ Catania | 37.5027 | 15.0873
+ Palermo | 40.0000 | 13.3614
+(2 rows)
+
+-- update both coordinates at once
+update db15_w_1key_geo set lat = 41, long = 14 where value = 'Catania';
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value  |   lat   |  long   
+---------+---------+---------
+ Catania | 41.0000 | 14.0000
+ Palermo | 40.0000 | 13.3614
+(2 rows)
+
+-- rename a member; its position must carry over
+update db15_w_1key_geo set value = 'Palermo2' where value = 'Palermo';
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value   |   lat   |  long   
+----------+---------+---------
+ Catania  | 41.0000 | 14.0000
+ Palermo2 | 40.0000 | 13.3614
+(2 rows)
+
+-- rename a member and change a coordinate in the same update
+update db15_w_1key_geo set value = 'Catania2', lat = 42 where value = 'Catania';
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value   |   lat   |  long   
+----------+---------+---------
+ Catania2 | 42.0000 | 14.0000
+ Palermo2 | 40.0000 | 13.3614
+(2 rows)
+
+delete from db15_w_1key_geo where value = 'Palermo2';
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value   |   lat   |  long   
+----------+---------+---------
+ Catania2 | 42.0000 | 14.0000
+(1 row)
+
+delete from db15_w_1key_geo;
+-- geo tables require singleton_key
+create foreign table db15_geo_no_singleton(key text, lat double precision, long double precision)
+       server localredis
+       options (tabletype 'geo', database '15');
+select * from db15_geo_no_singleton;
+ERROR:  geo tables are only supported with singleton_key
+drop foreign table db15_geo_no_singleton;
 -- non-singleton scalar table no prefix no keyset
 create foreign table db15_w_scalar(key text, val text)
        server localredis

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -745,6 +745,18 @@ from db15_w_1key_geo order by value;
  Palermo2 | 40.0000 | 13.3614
 (2 rows)
 
+-- a rename whose coordinates Redis rejects must leave the old member alone
+-- rather than deleting it on the way to a failed add
+update db15_w_1key_geo set value = 'Catania3', lat = 99 where value = 'Catania2';
+ERROR:  setting element Catania3: ERR invalid longitude,latitude pair 14.000002,99.000000
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+  value   |   lat   |  long   
+----------+---------+---------
+ Catania2 | 42.0000 | 14.0000
+ Palermo2 | 40.0000 | 13.3614
+(2 rows)
+
 delete from db15_w_1key_geo where value = 'Palermo2';
 select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
 from db15_w_1key_geo order by value;

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -761,6 +761,106 @@ create foreign table db15_geo_no_singleton(key text, lat double precision, long 
 select * from db15_geo_no_singleton;
 ERROR:  geo tables are only supported with singleton_key
 drop foreign table db15_geo_no_singleton;
+-- singleton geo4326 table (PostGIS-friendly EWKT variant of geo)
+create foreign table db15_w_1key_geo4326(value text, point text)
+       server localredis
+       options (singleton_key 'w_1key_geo4326', tabletype 'geo4326', database '15');
+select * from db15_w_1key_geo4326;
+ value | point 
+-------+-------
+(0 rows)
+
+insert into db15_w_1key_geo4326 (value, point) values
+       ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)'),
+       ('Catania', 'SRID=4326;POINT(15.087269 37.502669)');
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+  value  |  long   |   lat   
+---------+---------+---------
+ Catania | 15.0873 | 37.5027
+ Palermo | 13.3614 | 38.1156
+(2 rows)
+
+-- duplicate member is rejected
+insert into db15_w_1key_geo4326 (value, point) values ('Palermo', 'SRID=4326;POINT(0 0)');
+ERROR:  key already exists: Palermo
+-- a plain WKT point with no SRID prefix is accepted (SRID 4326 is implied)
+insert into db15_w_1key_geo4326 (value, point) values ('Messina', 'POINT(15.556349 38.193299)');
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+  value  |  long   |   lat   
+---------+---------+---------
+ Catania | 15.0873 | 37.5027
+ Messina | 15.5563 | 38.1933
+ Palermo | 13.3614 | 38.1156
+(3 rows)
+
+-- a point with a non-4326 SRID is rejected
+insert into db15_w_1key_geo4326 (value, point) values ('Rome', 'SRID=3857;POINT(1391469 5146449)');
+ERROR:  unsupported SRID 3857 in geo4326 point value: only 4326 is supported
+-- malformed point text is rejected
+insert into db15_w_1key_geo4326 (value, point) values ('Bad', 'not a point');
+ERROR:  invalid geo4326 point value: "not a point"
+delete from db15_w_1key_geo4326 where value = 'Messina';
+-- update the whole point at once (partial-coordinate update, as with plain
+-- geo, isn't meaningful here since there's only one point column)
+update db15_w_1key_geo4326 set point = 'SRID=4326;POINT(14 41)' where value = 'Catania';
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+  value  |  long   |   lat   
+---------+---------+---------
+ Catania | 14.0000 | 41.0000
+ Palermo | 13.3614 | 38.1156
+(2 rows)
+
+-- rename a member; its position must carry over
+update db15_w_1key_geo4326 set value = 'Palermo2' where value = 'Palermo';
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+  value   |  long   |   lat   
+----------+---------+---------
+ Catania  | 14.0000 | 41.0000
+ Palermo2 | 13.3614 | 38.1156
+(2 rows)
+
+-- rename a member and change its point in the same update
+update db15_w_1key_geo4326 set value = 'Catania2', point = 'SRID=4326;POINT(14.5 41.5)' where value = 'Catania';
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+  value   |  long   |   lat   
+----------+---------+---------
+ Catania2 | 14.5000 | 41.5000
+ Palermo2 | 13.3614 | 38.1156
+(2 rows)
+
+delete from db15_w_1key_geo4326 where value = 'Palermo2';
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+  value   |  long   |   lat   
+----------+---------+---------
+ Catania2 | 14.5000 | 41.5000
+(1 row)
+
+delete from db15_w_1key_geo4326;
+-- geo4326 tables require singleton_key
+create foreign table db15_geo4326_no_singleton(key text, point text)
+       server localredis
+       options (tabletype 'geo4326', database '15');
+select * from db15_geo4326_no_singleton;
+ERROR:  geo tables are only supported with singleton_key
+drop foreign table db15_geo4326_no_singleton;
 -- non-singleton scalar table no prefix no keyset
 create foreign table db15_w_scalar(key text, val text)
        server localredis

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -753,6 +753,11 @@ from db15_w_1key_geo order by value;
  Catania2 | 42.0000 | 14.0000
 (1 row)
 
+-- NULL coordinates are rejected, not silently stored as 0 (and not a crash)
+insert into db15_w_1key_geo (value, lat, long) values ('NullLat', NULL, 5);
+ERROR:  cannot insert NULL coordinates into a Redis geo table
+insert into db15_w_1key_geo (value, lat, long) values ('NullLong', 5, NULL);
+ERROR:  cannot insert NULL coordinates into a Redis geo table
 delete from db15_w_1key_geo;
 -- geo tables require singleton_key
 create foreign table db15_geo_no_singleton(key text, lat double precision, long double precision)
@@ -806,6 +811,9 @@ ERROR:  unsupported SRID 3857 in geo point value: only 4326 is supported
 -- malformed point text is rejected
 insert into db15_w_1key_geo_ewkt (value, point) values ('Bad', 'not a point');
 ERROR:  invalid geo point value: "not a point"
+-- a NULL point is rejected (regression: previously a NULL-pointer crash)
+insert into db15_w_1key_geo_ewkt (value, point) values ('Null', NULL);
+ERROR:  cannot insert NULL value into a Redis table
 delete from db15_w_1key_geo_ewkt where value = 'Messina';
 -- update the whole point at once (partial-coordinate update, as with plain
 -- geo, isn't meaningful here since there's only one point column)

--- a/test/expected/redis_fdw.out
+++ b/test/expected/redis_fdw.out
@@ -761,22 +761,23 @@ create foreign table db15_geo_no_singleton(key text, lat double precision, long 
 select * from db15_geo_no_singleton;
 ERROR:  geo tables are only supported with singleton_key
 drop foreign table db15_geo_no_singleton;
--- singleton geo4326 table (PostGIS-friendly EWKT variant of geo)
-create foreign table db15_w_1key_geo4326(value text, point text)
+-- singleton geo table, EWKT shape (PostGIS-friendly variant of geo, chosen
+-- by the declared column shape rather than a separate tabletype)
+create foreign table db15_w_1key_geo_ewkt(value text, point text)
        server localredis
-       options (singleton_key 'w_1key_geo4326', tabletype 'geo4326', database '15');
-select * from db15_w_1key_geo4326;
+       options (singleton_key 'w_1key_geo_ewkt', tabletype 'geo', database '15');
+select * from db15_w_1key_geo_ewkt;
  value | point 
 -------+-------
 (0 rows)
 
-insert into db15_w_1key_geo4326 (value, point) values
+insert into db15_w_1key_geo_ewkt (value, point) values
        ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)'),
        ('Catania', 'SRID=4326;POINT(15.087269 37.502669)');
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
   value  |  long   |   lat   
 ---------+---------+---------
  Catania | 15.0873 | 37.5027
@@ -784,14 +785,14 @@ from db15_w_1key_geo4326 order by value;
 (2 rows)
 
 -- duplicate member is rejected
-insert into db15_w_1key_geo4326 (value, point) values ('Palermo', 'SRID=4326;POINT(0 0)');
+insert into db15_w_1key_geo_ewkt (value, point) values ('Palermo', 'SRID=4326;POINT(0 0)');
 ERROR:  key already exists: Palermo
 -- a plain WKT point with no SRID prefix is accepted (SRID 4326 is implied)
-insert into db15_w_1key_geo4326 (value, point) values ('Messina', 'POINT(15.556349 38.193299)');
+insert into db15_w_1key_geo_ewkt (value, point) values ('Messina', 'POINT(15.556349 38.193299)');
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
   value  |  long   |   lat   
 ---------+---------+---------
  Catania | 15.0873 | 37.5027
@@ -800,19 +801,19 @@ from db15_w_1key_geo4326 order by value;
 (3 rows)
 
 -- a point with a non-4326 SRID is rejected
-insert into db15_w_1key_geo4326 (value, point) values ('Rome', 'SRID=3857;POINT(1391469 5146449)');
-ERROR:  unsupported SRID 3857 in geo4326 point value: only 4326 is supported
+insert into db15_w_1key_geo_ewkt (value, point) values ('Rome', 'SRID=3857;POINT(1391469 5146449)');
+ERROR:  unsupported SRID 3857 in geo point value: only 4326 is supported
 -- malformed point text is rejected
-insert into db15_w_1key_geo4326 (value, point) values ('Bad', 'not a point');
-ERROR:  invalid geo4326 point value: "not a point"
-delete from db15_w_1key_geo4326 where value = 'Messina';
+insert into db15_w_1key_geo_ewkt (value, point) values ('Bad', 'not a point');
+ERROR:  invalid geo point value: "not a point"
+delete from db15_w_1key_geo_ewkt where value = 'Messina';
 -- update the whole point at once (partial-coordinate update, as with plain
 -- geo, isn't meaningful here since there's only one point column)
-update db15_w_1key_geo4326 set point = 'SRID=4326;POINT(14 41)' where value = 'Catania';
+update db15_w_1key_geo_ewkt set point = 'SRID=4326;POINT(14 41)' where value = 'Catania';
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
   value  |  long   |   lat   
 ---------+---------+---------
  Catania | 14.0000 | 41.0000
@@ -820,11 +821,11 @@ from db15_w_1key_geo4326 order by value;
 (2 rows)
 
 -- rename a member; its position must carry over
-update db15_w_1key_geo4326 set value = 'Palermo2' where value = 'Palermo';
+update db15_w_1key_geo_ewkt set value = 'Palermo2' where value = 'Palermo';
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
   value   |  long   |   lat   
 ----------+---------+---------
  Catania  | 14.0000 | 41.0000
@@ -832,35 +833,90 @@ from db15_w_1key_geo4326 order by value;
 (2 rows)
 
 -- rename a member and change its point in the same update
-update db15_w_1key_geo4326 set value = 'Catania2', point = 'SRID=4326;POINT(14.5 41.5)' where value = 'Catania';
+update db15_w_1key_geo_ewkt set value = 'Catania2', point = 'SRID=4326;POINT(14.5 41.5)' where value = 'Catania';
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
   value   |  long   |   lat   
 ----------+---------+---------
  Catania2 | 14.5000 | 41.5000
  Palermo2 | 13.3614 | 38.1156
 (2 rows)
 
-delete from db15_w_1key_geo4326 where value = 'Palermo2';
+delete from db15_w_1key_geo_ewkt where value = 'Palermo2';
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
   value   |  long   |   lat   
 ----------+---------+---------
  Catania2 | 14.5000 | 41.5000
 (1 row)
 
-delete from db15_w_1key_geo4326;
--- geo4326 tables require singleton_key
-create foreign table db15_geo4326_no_singleton(key text, point text)
+delete from db15_w_1key_geo_ewkt;
+-- geo tables (either shape) require singleton_key
+create foreign table db15_geo_ewkt_no_singleton(key text, point text)
        server localredis
-       options (tabletype 'geo4326', database '15');
-select * from db15_geo4326_no_singleton;
+       options (tabletype 'geo', database '15');
+select * from db15_geo_ewkt_no_singleton;
 ERROR:  geo tables are only supported with singleton_key
-drop foreign table db15_geo4326_no_singleton;
+drop foreign table db15_geo_ewkt_no_singleton;
+-- geo tables must have one of the two supported column shapes: (text, text)
+-- for an EWKT point, or (text, double precision, double precision) for
+-- separate lat/long columns
+-- the member column must be text as well: the shape error has always
+-- advertised (text, ...), and a bytea member would otherwise reach the bytea
+-- tuple path, which fills columns from data - never populated by a geo scan
+create foreign table db15_geo_bytea_member(value bytea, lat double precision, long double precision)
+       server localredis
+       options (singleton_key 'w_1key_geo', tabletype 'geo', database '15');
+select * from db15_geo_bytea_member;
+ERROR:  geo tables must have columns (text, text) for an EWKT point, or (text, double precision, double precision) for latitude/longitude
+drop foreign table db15_geo_bytea_member;
+create foreign table db15_geo_bad_shape(value text, foo text, bar text)
+       server localredis
+       options (singleton_key 'w_1key_geo_bad_shape', tabletype 'geo', database '15');
+select * from db15_geo_bad_shape;
+ERROR:  geo tables must have columns (text, text) for an EWKT point, or (text, double precision, double precision) for latitude/longitude
+drop foreign table db15_geo_bad_shape;
+-- a column count that is neither geo shape is rejected by the count check,
+-- with the count message rather than the shape message
+create foreign table db15_geo_too_many_cols(value text, lat double precision,
+                                            long double precision, extra text)
+       server localredis
+       options (singleton_key 'w_1key_geo', tabletype 'geo', database '15');
+select * from db15_geo_too_many_cols;
+ERROR:  table has incorrect number of columns
+drop foreign table db15_geo_too_many_cols;
+-- a trailing dropped column does not change the shape: this is still the
+-- two-column EWKT geo table it was declared as, for both read and write
+create foreign table db15_geo_dropped_trailing(value text, point text, junk int)
+       server localredis
+       options (singleton_key 'w_1key_geo_ewkt', tabletype 'geo', database '15');
+alter table db15_geo_dropped_trailing drop column junk;
+insert into db15_geo_dropped_trailing (value, point) values
+       ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)');
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_geo_dropped_trailing order by value;
+  value  |  long   |   lat   
+---------+---------+---------
+ Palermo | 13.3614 | 38.1156
+(1 row)
+
+delete from db15_geo_dropped_trailing;
+drop foreign table db15_geo_dropped_trailing;
+-- a dropped column among the columns the table type uses is rejected, since
+-- the scan fills values[] by position
+create foreign table db15_geo_dropped_interleaved(value text, junk int, point text)
+       server localredis
+       options (singleton_key 'w_1key_geo_ewkt', tabletype 'geo', database '15');
+alter table db15_geo_dropped_interleaved drop column junk;
+select * from db15_geo_dropped_interleaved;
+ERROR:  table has a dropped column among the columns this table type uses
+drop foreign table db15_geo_dropped_interleaved;
 -- non-singleton scalar table no prefix no keyset
 create foreign table db15_w_scalar(key text, val text)
        server localredis

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -462,6 +462,13 @@ update db15_w_1key_geo set value = 'Catania2', lat = 42 where value = 'Catania';
 select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
 from db15_w_1key_geo order by value;
 
+-- a rename whose coordinates Redis rejects must leave the old member alone
+-- rather than deleting it on the way to a failed add
+update db15_w_1key_geo set value = 'Catania3', lat = 99 where value = 'Catania2';
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
 delete from db15_w_1key_geo where value = 'Palermo2';
 
 select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -478,6 +478,85 @@ select * from db15_geo_no_singleton;
 
 drop foreign table db15_geo_no_singleton;
 
+-- singleton geo4326 table (PostGIS-friendly EWKT variant of geo)
+
+create foreign table db15_w_1key_geo4326(value text, point text)
+       server localredis
+       options (singleton_key 'w_1key_geo4326', tabletype 'geo4326', database '15');
+
+select * from db15_w_1key_geo4326;
+
+insert into db15_w_1key_geo4326 (value, point) values
+       ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)'),
+       ('Catania', 'SRID=4326;POINT(15.087269 37.502669)');
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+
+-- duplicate member is rejected
+insert into db15_w_1key_geo4326 (value, point) values ('Palermo', 'SRID=4326;POINT(0 0)');
+
+-- a plain WKT point with no SRID prefix is accepted (SRID 4326 is implied)
+insert into db15_w_1key_geo4326 (value, point) values ('Messina', 'POINT(15.556349 38.193299)');
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+
+-- a point with a non-4326 SRID is rejected
+insert into db15_w_1key_geo4326 (value, point) values ('Rome', 'SRID=3857;POINT(1391469 5146449)');
+
+-- malformed point text is rejected
+insert into db15_w_1key_geo4326 (value, point) values ('Bad', 'not a point');
+
+delete from db15_w_1key_geo4326 where value = 'Messina';
+
+-- update the whole point at once (partial-coordinate update, as with plain
+-- geo, isn't meaningful here since there's only one point column)
+update db15_w_1key_geo4326 set point = 'SRID=4326;POINT(14 41)' where value = 'Catania';
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+
+-- rename a member; its position must carry over
+update db15_w_1key_geo4326 set value = 'Palermo2' where value = 'Palermo';
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+
+-- rename a member and change its point in the same update
+update db15_w_1key_geo4326 set value = 'Catania2', point = 'SRID=4326;POINT(14.5 41.5)' where value = 'Catania';
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+
+delete from db15_w_1key_geo4326 where value = 'Palermo2';
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_w_1key_geo4326 order by value;
+
+delete from db15_w_1key_geo4326;
+
+-- geo4326 tables require singleton_key
+create foreign table db15_geo4326_no_singleton(key text, point text)
+       server localredis
+       options (tabletype 'geo4326', database '15');
+
+select * from db15_geo4326_no_singleton;
+
+drop foreign table db15_geo4326_no_singleton;
+
 -- non-singleton scalar table no prefix no keyset
 
 create foreign table db15_w_scalar(key text, val text)

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -478,84 +478,151 @@ select * from db15_geo_no_singleton;
 
 drop foreign table db15_geo_no_singleton;
 
--- singleton geo4326 table (PostGIS-friendly EWKT variant of geo)
+-- singleton geo table, EWKT shape (PostGIS-friendly variant of geo, chosen
+-- by the declared column shape rather than a separate tabletype)
 
-create foreign table db15_w_1key_geo4326(value text, point text)
+create foreign table db15_w_1key_geo_ewkt(value text, point text)
        server localredis
-       options (singleton_key 'w_1key_geo4326', tabletype 'geo4326', database '15');
+       options (singleton_key 'w_1key_geo_ewkt', tabletype 'geo', database '15');
 
-select * from db15_w_1key_geo4326;
+select * from db15_w_1key_geo_ewkt;
 
-insert into db15_w_1key_geo4326 (value, point) values
+insert into db15_w_1key_geo_ewkt (value, point) values
        ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)'),
        ('Catania', 'SRID=4326;POINT(15.087269 37.502669)');
 
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
 
 -- duplicate member is rejected
-insert into db15_w_1key_geo4326 (value, point) values ('Palermo', 'SRID=4326;POINT(0 0)');
+insert into db15_w_1key_geo_ewkt (value, point) values ('Palermo', 'SRID=4326;POINT(0 0)');
 
 -- a plain WKT point with no SRID prefix is accepted (SRID 4326 is implied)
-insert into db15_w_1key_geo4326 (value, point) values ('Messina', 'POINT(15.556349 38.193299)');
+insert into db15_w_1key_geo_ewkt (value, point) values ('Messina', 'POINT(15.556349 38.193299)');
 
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
 
 -- a point with a non-4326 SRID is rejected
-insert into db15_w_1key_geo4326 (value, point) values ('Rome', 'SRID=3857;POINT(1391469 5146449)');
+insert into db15_w_1key_geo_ewkt (value, point) values ('Rome', 'SRID=3857;POINT(1391469 5146449)');
 
 -- malformed point text is rejected
-insert into db15_w_1key_geo4326 (value, point) values ('Bad', 'not a point');
+insert into db15_w_1key_geo_ewkt (value, point) values ('Bad', 'not a point');
 
-delete from db15_w_1key_geo4326 where value = 'Messina';
+delete from db15_w_1key_geo_ewkt where value = 'Messina';
 
 -- update the whole point at once (partial-coordinate update, as with plain
 -- geo, isn't meaningful here since there's only one point column)
-update db15_w_1key_geo4326 set point = 'SRID=4326;POINT(14 41)' where value = 'Catania';
+update db15_w_1key_geo_ewkt set point = 'SRID=4326;POINT(14 41)' where value = 'Catania';
 
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
 
 -- rename a member; its position must carry over
-update db15_w_1key_geo4326 set value = 'Palermo2' where value = 'Palermo';
+update db15_w_1key_geo_ewkt set value = 'Palermo2' where value = 'Palermo';
 
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
 
 -- rename a member and change its point in the same update
-update db15_w_1key_geo4326 set value = 'Catania2', point = 'SRID=4326;POINT(14.5 41.5)' where value = 'Catania';
+update db15_w_1key_geo_ewkt set value = 'Catania2', point = 'SRID=4326;POINT(14.5 41.5)' where value = 'Catania';
 
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
 
-delete from db15_w_1key_geo4326 where value = 'Palermo2';
+delete from db15_w_1key_geo_ewkt where value = 'Palermo2';
 
 select value,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
        round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
-from db15_w_1key_geo4326 order by value;
+from db15_w_1key_geo_ewkt order by value;
 
-delete from db15_w_1key_geo4326;
+delete from db15_w_1key_geo_ewkt;
 
--- geo4326 tables require singleton_key
-create foreign table db15_geo4326_no_singleton(key text, point text)
+-- geo tables (either shape) require singleton_key
+create foreign table db15_geo_ewkt_no_singleton(key text, point text)
        server localredis
-       options (tabletype 'geo4326', database '15');
+       options (tabletype 'geo', database '15');
 
-select * from db15_geo4326_no_singleton;
+select * from db15_geo_ewkt_no_singleton;
 
-drop foreign table db15_geo4326_no_singleton;
+drop foreign table db15_geo_ewkt_no_singleton;
+
+-- geo tables must have one of the two supported column shapes: (text, text)
+-- for an EWKT point, or (text, double precision, double precision) for
+-- separate lat/long columns
+-- the member column must be text as well: the shape error has always
+-- advertised (text, ...), and a bytea member would otherwise reach the bytea
+-- tuple path, which fills columns from data - never populated by a geo scan
+
+create foreign table db15_geo_bytea_member(value bytea, lat double precision, long double precision)
+       server localredis
+       options (singleton_key 'w_1key_geo', tabletype 'geo', database '15');
+
+select * from db15_geo_bytea_member;
+
+drop foreign table db15_geo_bytea_member;
+
+create foreign table db15_geo_bad_shape(value text, foo text, bar text)
+       server localredis
+       options (singleton_key 'w_1key_geo_bad_shape', tabletype 'geo', database '15');
+
+select * from db15_geo_bad_shape;
+
+drop foreign table db15_geo_bad_shape;
+
+-- a column count that is neither geo shape is rejected by the count check,
+-- with the count message rather than the shape message
+create foreign table db15_geo_too_many_cols(value text, lat double precision,
+                                            long double precision, extra text)
+       server localredis
+       options (singleton_key 'w_1key_geo', tabletype 'geo', database '15');
+
+select * from db15_geo_too_many_cols;
+
+drop foreign table db15_geo_too_many_cols;
+
+-- a trailing dropped column does not change the shape: this is still the
+-- two-column EWKT geo table it was declared as, for both read and write
+create foreign table db15_geo_dropped_trailing(value text, point text, junk int)
+       server localredis
+       options (singleton_key 'w_1key_geo_ewkt', tabletype 'geo', database '15');
+
+alter table db15_geo_dropped_trailing drop column junk;
+
+insert into db15_geo_dropped_trailing (value, point) values
+       ('Palermo', 'SRID=4326;POINT(13.361389 38.115556)');
+
+select value,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[1]::numeric, 4) as long,
+       round((regexp_match(point, 'POINT\(([-0-9.eE]+) ([-0-9.eE]+)\)'))[2]::numeric, 4) as lat
+from db15_geo_dropped_trailing order by value;
+
+delete from db15_geo_dropped_trailing;
+
+drop foreign table db15_geo_dropped_trailing;
+
+-- a dropped column among the columns the table type uses is rejected, since
+-- the scan fills values[] by position
+create foreign table db15_geo_dropped_interleaved(value text, junk int, point text)
+       server localredis
+       options (singleton_key 'w_1key_geo_ewkt', tabletype 'geo', database '15');
+
+alter table db15_geo_dropped_interleaved drop column junk;
+
+select * from db15_geo_dropped_interleaved;
+
+drop foreign table db15_geo_dropped_interleaved;
 
 -- non-singleton scalar table no prefix no keyset
 

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -420,6 +420,64 @@ delete from db15_w_1key_zsetx where key = 'z';
 
 select * from db15_w_1key_zsetx order by key;
 
+-- singleton geo table
+
+create foreign table db15_w_1key_geo(value text, lat double precision, long double precision)
+       server localredis
+       options (singleton_key 'w_1key_geo', tabletype 'geo', database '15');
+
+select * from db15_w_1key_geo;
+
+insert into db15_w_1key_geo (value, lat, long) values
+       ('Palermo', 38.115556, 13.361389),
+       ('Catania', 37.502669, 15.087269);
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
+-- duplicate member is rejected
+insert into db15_w_1key_geo (value, lat, long) values ('Palermo', 0, 0);
+
+-- update just one coordinate - the other must be preserved
+update db15_w_1key_geo set lat = 40 where value = 'Palermo';
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
+-- update both coordinates at once
+update db15_w_1key_geo set lat = 41, long = 14 where value = 'Catania';
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
+-- rename a member; its position must carry over
+update db15_w_1key_geo set value = 'Palermo2' where value = 'Palermo';
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
+-- rename a member and change a coordinate in the same update
+update db15_w_1key_geo set value = 'Catania2', lat = 42 where value = 'Catania';
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
+delete from db15_w_1key_geo where value = 'Palermo2';
+
+select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
+from db15_w_1key_geo order by value;
+
+delete from db15_w_1key_geo;
+
+-- geo tables require singleton_key
+create foreign table db15_geo_no_singleton(key text, lat double precision, long double precision)
+       server localredis
+       options (tabletype 'geo', database '15');
+
+select * from db15_geo_no_singleton;
+
+drop foreign table db15_geo_no_singleton;
+
 -- non-singleton scalar table no prefix no keyset
 
 create foreign table db15_w_scalar(key text, val text)

--- a/test/sql/redis_fdw.sql
+++ b/test/sql/redis_fdw.sql
@@ -467,6 +467,10 @@ delete from db15_w_1key_geo where value = 'Palermo2';
 select value, round(lat::numeric, 4) as lat, round(long::numeric, 4) as long
 from db15_w_1key_geo order by value;
 
+-- NULL coordinates are rejected, not silently stored as 0 (and not a crash)
+insert into db15_w_1key_geo (value, lat, long) values ('NullLat', NULL, 5);
+insert into db15_w_1key_geo (value, lat, long) values ('NullLong', 5, NULL);
+
 delete from db15_w_1key_geo;
 
 -- geo tables require singleton_key
@@ -512,6 +516,9 @@ insert into db15_w_1key_geo_ewkt (value, point) values ('Rome', 'SRID=3857;POINT
 
 -- malformed point text is rejected
 insert into db15_w_1key_geo_ewkt (value, point) values ('Bad', 'not a point');
+
+-- a NULL point is rejected (regression: previously a NULL-pointer crash)
+insert into db15_w_1key_geo_ewkt (value, point) values ('Null', NULL);
 
 delete from db15_w_1key_geo_ewkt where value = 'Messina';
 


### PR DESCRIPTION
Replaces #56, which GitHub closed automatically after a rebase used the
wrong base and briefly collapsed this branch. No work was lost.

Now rebased onto master and carrying only its own six commits. The
reconciliation with #51 (bytea) is done: the singleton scan's branches are
ordered so bytea keeps its Datum path and geo keeps its two cstring cases,
and geo's shape check now enforces the text member column its error message
has always advertised — a bytea member would otherwise have reached the
bytea tuple path, which fills columns from data that a geo scan never
populates. Covered by a new test.
needs the same treatment rather than a mechanical merge.

---

## Summary
- Adds `tabletype 'geo'`, exposing a Redis geospatial index (a zset internally, with each member's score encoding its coordinates) as rows of `(member, lat, long)`. Only the singleton_key form is supported.
- **Read**: there's no direct "get everything" geo command, so scans use `GEOSEARCH ... FROMLONLAT 0 0 BYBOX <earth-covering box> WITHCOORD`, which returns every member with its decoded coordinates in one round trip — this means redis_fdw never has to reimplement Redis's internal 52-bit geohash encoding itself.
- **Write**: `INSERT` uses `GEOADD`; membership/uniqueness checks reuse `ZRANK` and `DELETE` reuses `ZREM`, since geo sets are zsets under the hood.
- **Update**: supports changing the member name, either coordinate, or both at once. Updating only one coordinate fetches the other via `GEOPOS` (factored into `redis_geo_fill_missing_coords()`) so it isn't lost — mirroring how singleton zset updates fetch the current score via `ZSCORE` when only the member is being renamed. Tested all four combinations (lat-only, both coords, rename-only, rename+coord) end-to-end.
- Redis's geohash encoding has inherent sub-meter precision loss, so a coordinate read back may differ very slightly from what was inserted — documented rather than worked around.
- **PostGIS interop, documented not coded**: redis_fdw itself has no PostGIS dependency and never will need one — the README now includes a `geometry(Point, 4326)` view + `INSTEAD OF` trigger recipe that layers full PostGIS read/write access on top of a plain geo table, entirely in SQL. This was **actually run end-to-end** against a real PostgreSQL 16 + PostGIS 3.4 install (view creation, INSERT/SELECT/UPDATE/DELETE through the view, and an `ST_Distance` query — not just written and assumed correct).

Addresses #15. This design (plain columns in the FDW + an optional pure-SQL PostGIS layer, rather than a PostGIS dependency in the C extension, and rather than reimplementing geohash math) was discussed and agreed on before implementation.

## Dependency
This targets `redis-string-optimize` (#50), which targets `redis-command-refactor` (#49), which targets `concache` (#48). Should be merged after that stack, in order.

## Validation
- Full regression suite passes, with new tests covering insert, duplicate-member rejection, partial/full coordinate updates, member rename (with and without a simultaneous coordinate change), delete, and the singleton_key-required validation error.
- The PostGIS recipe in the README was executed against a real PostgreSQL 16 + PostGIS 3.4 instance, not just reviewed.

## Test plan
- [x] Full regression suite passes (including new geo tests)
- [x] INSERT/SELECT/UPDATE (all 4 variants)/DELETE verified end-to-end against Valkey
- [x] `singleton_key` requirement enforced with a clear error
- [x] PostGIS view+trigger recipe verified end-to-end against real PostGIS

